### PR TITLE
CFY-5166 server NICs ordering depends on the declared relationships

### DIFF
--- a/nova_plugin/tests/resources/test-networks-relationships-blueprint.yaml
+++ b/nova_plugin/tests/resources/test-networks-relationships-blueprint.yaml
@@ -1,0 +1,82 @@
+
+tosca_definitions_version: cloudify_dsl_1_2
+
+imports:
+  - http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
+  - plugin.yaml
+
+inputs:
+  management_network_name:
+    type: string
+    default: network1
+
+node_templates:
+  server:
+    type: cloudify.openstack.nodes.Server
+    properties:
+      install_agent: false
+      management_network_name: {get_input: management_network_name}
+      server:
+        key_name: key
+        scheduler_hints:
+          group: affinity-group-id
+      openstack_config: &OPENSTACK_CONFIG
+        username: aaa
+        password: aaa
+        tenant_name: aaa
+        auth_url: aaa
+    relationships:
+      - target: network1
+        type: cloudify.relationships.connected_to
+      - target: network2
+        type: cloudify.relationships.connected_to
+      - target: network3
+        type: cloudify.relationships.connected_to
+      - target: network4
+        type: cloudify.relationships.connected_to
+      - target: network5
+        type: cloudify.relationships.connected_to
+      - target: network6
+        type: cloudify.relationships.connected_to
+
+  network1:
+    type: cloudify.openstack.nodes.Network
+    properties: &NETWORK_CONFIG
+      use_external_resource: true
+      resource_id: network1
+      openstack_config: *OPENSTACK_CONFIG
+
+  network2: 
+    type: cloudify.openstack.nodes.Network
+    properties:
+      use_external_resource: true
+      resource_id: network2
+      openstack_config: *OPENSTACK_CONFIG
+
+  network3: 
+    type: cloudify.openstack.nodes.Network
+    properties:
+      use_external_resource: true
+      resource_id: network3
+      openstack_config: *OPENSTACK_CONFIG
+
+  network4: 
+    type: cloudify.openstack.nodes.Network
+    properties:
+      use_external_resource: true
+      resource_id: network4
+      openstack_config: *OPENSTACK_CONFIG
+
+  network5: 
+    type: cloudify.openstack.nodes.Network
+    properties:
+      use_external_resource: true
+      resource_id: network5
+      openstack_config: *OPENSTACK_CONFIG
+
+  network6: 
+    type: cloudify.openstack.nodes.Network
+    properties:
+      use_external_resource: true
+      resource_id: network6
+      openstack_config: *OPENSTACK_CONFIG

--- a/nova_plugin/tests/test_relationships.py
+++ b/nova_plugin/tests/test_relationships.py
@@ -1,0 +1,224 @@
+#########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+"""Test the functions related to retrieving relationship information.
+
+Functions under test are mostly inside openstack_plugin_common:
+get_relationships_by_openstack_type
+get_connected_nodes_by_openstack_type
+get_openstack_ids_of_connected_nodes_by_openstack_type
+get_single_connected_node_by_openstack_type
+"""
+
+import uuid
+from unittest import TestCase
+
+from neutron_plugin.network import NETWORK_OPENSTACK_TYPE
+
+from cloudify.exceptions import NonRecoverableError
+
+from cloudify.mocks import (
+    MockCloudifyContext,
+    MockNodeContext,
+    MockNodeInstanceContext,
+    MockRelationshipContext,
+    MockRelationshipSubjectContext,
+)
+from openstack_plugin_common import (
+    OPENSTACK_ID_PROPERTY,
+    OPENSTACK_TYPE_PROPERTY,
+    get_openstack_id_of_single_connected_node_by_openstack_type,
+    get_openstack_ids_of_connected_nodes_by_openstack_type,
+    get_relationships_by_openstack_type,
+    get_single_connected_node_by_openstack_type,
+)
+
+
+class RelationshipsTestBase(TestCase):
+    def _make_vm_ctx_with_relationships(self, rel_specs):
+        """Prepare a mock CloudifyContext from the given relationship spec.
+
+        rel_specs is an ordered collection of relationship specs - dicts
+        with the keys "node" and "instance" used to construct the
+        MockNodeContext and the MockNodeInstanceContext, and optionally a
+        "type" key.
+        Examples: [
+            {},
+            {"node": {"id": 5}},
+            {
+                "type": "some_type",
+                "instance": {
+                    "id": 3,
+                    "runtime_properties":{}
+                }
+            }
+        ]
+        """
+        relationships = []
+        for rel_spec in rel_specs:
+            node = rel_spec.get('node', {})
+            node_id = node.pop('id', uuid.uuid4().hex)
+
+            instance = rel_spec.get('instance', {})
+            instance_id = instance.pop('id', '{0}_{1}'.format(
+                node_id, uuid.uuid4().hex))
+
+            node_ctx = MockNodeContext(id=node_id, **node)
+            instance_ctx = MockNodeInstanceContext(id=instance_id, **instance)
+
+            rel_subject_ctx = MockRelationshipSubjectContext(
+                node=node_ctx, instance=instance_ctx)
+            rel_type = rel_spec.get('type')
+            rel_ctx = MockRelationshipContext(target=rel_subject_ctx,
+                                              type=rel_type)
+            relationships.append(rel_ctx)
+        return MockCloudifyContext(node_id='vm', relationships=relationships)
+
+
+class TestGettingRelatedResources(RelationshipsTestBase):
+
+    def test_get_relationships_finds_all_by_type(self):
+        """get_relationships_by_openstack_type returns all rels that match."""
+        rel_specs = [{
+            'instance': {
+                'id': instance_id,
+                'runtime_properties': {
+                    OPENSTACK_TYPE_PROPERTY: NETWORK_OPENSTACK_TYPE
+                }
+            }
+        } for instance_id in range(3)]
+
+        rel_specs.append({
+            'instance': {
+                'runtime_properties': {
+                    OPENSTACK_TYPE_PROPERTY: 'something else'
+                }
+            }
+        })
+
+        ctx = self._make_vm_ctx_with_relationships(rel_specs)
+        filtered = get_relationships_by_openstack_type(ctx,
+                                                       NETWORK_OPENSTACK_TYPE)
+        self.assertEqual(3, len(filtered))
+
+    def test_get_ids_of_nodes_by_type(self):
+
+        rel_spec = {
+            'instance': {
+                'runtime_properties': {
+                    OPENSTACK_TYPE_PROPERTY: NETWORK_OPENSTACK_TYPE,
+                    OPENSTACK_ID_PROPERTY: 'the node id'
+                }
+            }
+        }
+        ctx = self._make_vm_ctx_with_relationships([rel_spec])
+        ids = get_openstack_ids_of_connected_nodes_by_openstack_type(
+            ctx, NETWORK_OPENSTACK_TYPE)
+        self.assertEqual(['the node id'], ids)
+
+
+class TestGetSingleByID(RelationshipsTestBase):
+    def _make_instances(self, ids):
+        """Mock a context with relationships to instances with given ids."""
+        rel_specs = [{
+            'node': {
+                'id': node_id
+            },
+            'instance': {
+                'runtime_properties': {
+                    OPENSTACK_TYPE_PROPERTY: NETWORK_OPENSTACK_TYPE,
+                    OPENSTACK_ID_PROPERTY: node_id
+                }
+            }
+        } for node_id in ids]
+        return self._make_vm_ctx_with_relationships(rel_specs)
+
+    def test_get_single_id(self):
+        ctx = self._make_instances(['the node id'])
+        found_id = get_openstack_id_of_single_connected_node_by_openstack_type(
+            ctx, NETWORK_OPENSTACK_TYPE)
+        self.assertEqual('the node id', found_id)
+
+    def test_get_single_id_two_found(self):
+        ctx = self._make_instances([0, 1])
+        self.assertRaises(
+            NonRecoverableError,
+            get_openstack_id_of_single_connected_node_by_openstack_type, ctx,
+            NETWORK_OPENSTACK_TYPE)
+
+    def test_get_single_id_two_found_if_exists_true(self):
+        ctx = self._make_instances([0, 1])
+
+        try:
+            get_openstack_id_of_single_connected_node_by_openstack_type(
+                ctx, NETWORK_OPENSTACK_TYPE, if_exists=True)
+        except NonRecoverableError as e:
+            self.assertIn(NETWORK_OPENSTACK_TYPE, e.message)
+        else:
+            self.fail()
+
+    def test_get_single_id_if_exists_none_found(self):
+        ctx = self._make_instances([])
+        found = get_openstack_id_of_single_connected_node_by_openstack_type(
+            ctx, NETWORK_OPENSTACK_TYPE, if_exists=True)
+        self.assertIsNone(found)
+
+    def test_get_single_id_none_found(self):
+        rel_spec = []
+        ctx = self._make_vm_ctx_with_relationships(rel_spec)
+        self.assertRaises(
+            NonRecoverableError,
+            get_openstack_id_of_single_connected_node_by_openstack_type,
+            ctx,
+            NETWORK_OPENSTACK_TYPE)
+
+    def test_get_single_node(self):
+        ctx = self._make_instances(['the node id'])
+        found_node = get_single_connected_node_by_openstack_type(
+            ctx, NETWORK_OPENSTACK_TYPE)
+        self.assertEqual('the node id', found_node.id)
+
+    def test_get_single_node_two_found(self):
+        ctx = self._make_instances([0, 1])
+        self.assertRaises(
+            NonRecoverableError,
+            get_single_connected_node_by_openstack_type,
+            ctx, NETWORK_OPENSTACK_TYPE)
+
+    def test_get_single_node_two_found_if_exists(self):
+        ctx = self._make_instances([0, 1])
+
+        self.assertRaises(
+            NonRecoverableError,
+            get_single_connected_node_by_openstack_type,
+            ctx,
+            NETWORK_OPENSTACK_TYPE,
+            if_exists=True)
+
+    def test_get_single_node_if_exists_none_found(self):
+        ctx = self._make_instances([])
+
+        found = get_single_connected_node_by_openstack_type(
+            ctx, NETWORK_OPENSTACK_TYPE, if_exists=True)
+        self.assertIsNone(found)
+
+    def test_get_single_node_none_found(self):
+        ctx = self._make_instances([])
+
+        self.assertRaises(
+            NonRecoverableError,
+            get_single_connected_node_by_openstack_type,
+            ctx,
+            NETWORK_OPENSTACK_TYPE)

--- a/nova_plugin/tests/test_server.py
+++ b/nova_plugin/tests/test_server.py
@@ -19,6 +19,7 @@ import tempfile
 import unittest
 import mock
 
+from nova_plugin.server import _merge_nics
 import nova_plugin
 from cloudify.test_utils import workflow_test
 
@@ -171,3 +172,130 @@ class TestServer(unittest.TestCase):
                     'CloudifyAgent.agent_key_path',
                     new_callable=mock.PropertyMock, return_value=key_path):
                 cfy_local.execute('install', task_retries=5)
+
+
+@mock.patch('nova_plugin.server.start')
+@mock.patch('nova_plugin.server._handle_image_or_flavor')
+@mock.patch('nova_plugin.server._fail_on_missing_required_parameters')
+class TestServerNICs(unittest.TestCase):
+    blueprint_path = path.join('resources',
+                               'test-networks-relationships-blueprint.yaml')
+
+    @staticmethod
+    def mock_get_networks(neutron, name=None, **search_params):
+        networks = [
+            {'name': 'network1', 'id': '1'},
+            {'name': 'network2', 'id': '2'},
+            {'name': 'network3', 'id': '3'},
+            {'name': 'network4', 'id': '4'},
+            {'name': 'network5', 'id': '5'},
+            {'name': 'network6', 'id': '6'},
+            {'name': 'other', 'id': 'other'}
+        ]
+        # this method is used to both list all networks, and to search
+        # for networks by name - the mock needs to implement both cases
+        if name is not None:
+            return {'networks': [n for n in networks if n['name'] == name]}
+        return {'networks': networks}
+
+    @staticmethod
+    def mock_get_ports(neutron, name=None, **search_params):
+        ports = [
+            {'name': 'port1', 'id': 'port1'},
+        ]
+        # this method is used to both list all networks, and to search
+        # for networks by name - the mock needs to implement both cases
+        if name is not None:
+            return {'ports': [n for n in ports if n['name'] == name]}
+        return {'ports': ports}
+
+    def test_merge_prepends_management_network(self, *mocks):
+        """When the mgmt network isnt in a relationship, its the 1st nic."""
+        mgmt_network_id = 'management network'
+        nics = [{'net-id': 'other network'}]
+
+        merged = _merge_nics(mgmt_network_id, nics)
+
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(merged[0]['net-id'], 'management network')
+
+    def test_management_network_in_relationships(self, *mocks):
+        """When the mgmt network was in a relationship, it's not prepended."""
+        mgmt_network_id = 'management network'
+        nics = [{'net-id': 'other network'}, {'net-id': 'management network'}]
+
+        merged = _merge_nics(mgmt_network_id, nics)
+
+        self.assertEqual(nics, merged)
+
+    @workflow_test(blueprint_path, copy_plugin_yaml=True)
+    def test_nova_server_creation_nics_ordering(self, cfy_local, *mocks):
+        """NIC list keeps the order of the relationships from the blueprint.
+
+        The nics= list passed to nova.server.create should be ordered
+        depending on the relationships to the networks, as defined in the
+        blueprint.
+        This test unfortunately necessarily depends on dict ordering to fail:
+        it's still possible for the NICs to be correctly ordered by chance,
+        although with 6 elements, the chance is negligible.
+        """
+        with mock.patch('openstack_plugin_common.nova_client.servers.'
+                        'ServerManager.create') as mock_create, \
+            mock.patch('openstack_plugin_common.neutron_client.Client.'
+                       'list_networks', new=self.mock_get_networks), \
+            mock.patch('openstack_plugin_common.neutron_client.Client.'
+                       'list_ports', new=self.mock_get_ports):
+
+            cfy_local.execute('install', task_retries=0)
+
+        self.assertEqual(1, len(mock_create.mock_calls))
+        server_args, server_kwargs = mock_create.call_args_list[0]
+
+        network_ids = [n['net-id'] for n in server_kwargs['nics']]
+        self.assertEqual(['1', '2', '3', '4', '5', '6'], network_ids)
+
+    @workflow_test(blueprint_path, copy_plugin_yaml=True, inputs={
+        'management_network_name': 'other'
+    })
+    def test_server_creation_prepends_mgmt_network(self, cfy_local, *mocks):
+        """When the mgmt network isnt in a relationship, its the 1st nic.
+
+        Creating the server examines the relationships, and if it doesn't find
+        a relationship to the management network, id adds the network to the
+        NICs list anyway, as the first element.
+        """
+        with mock.patch('openstack_plugin_common.nova_client.servers.'
+                        'ServerManager.create') as mock_create, \
+            mock.patch('openstack_plugin_common.neutron_client.Client.'
+                       'list_networks', new=self.mock_get_networks):
+
+            cfy_local.execute('install', task_retries=0)
+
+        self.assertEqual(len(mock_create.mock_calls), 1)
+        server_args, server_kwargs = mock_create.call_args_list[0]
+
+        first_nic = server_kwargs['nics'][0]
+        self.assertEqual('other', first_nic['net-id'])
+
+    @workflow_test(blueprint_path, copy_plugin_yaml=True, inputs={
+        'management_network_name': 'network1'
+    })
+    def test_server_creation_uses_relation_mgmt_nic(self, cfy_local, *mocks):
+        """When the mgmt network is in a relationship, it isn't prepended.
+
+        If the server has a relationship to the management network,
+        a new NIC isn't prepended to the list.
+        """
+        with mock.patch('openstack_plugin_common.nova_client.servers.'
+                        'ServerManager.create') as mock_create, \
+            mock.patch('openstack_plugin_common.neutron_client.Client.'
+                       'list_networks', new=self.mock_get_networks):
+
+            cfy_local.execute('install', task_retries=0)
+
+        self.assertEqual(1, len(mock_create.mock_calls))
+        server_args, server_kwargs = mock_create.call_args_list[0]
+
+        # blueprint defines 6 network relationships, so there should be 6 NICs,
+        # not 7
+        self.assertEqual(6, len(server_kwargs['nics']))

--- a/openstack_plugin_common/__init__.py
+++ b/openstack_plugin_common/__init__.py
@@ -102,16 +102,21 @@ def provider(ctx):
     return ProviderContext(ctx.provider_context)
 
 
-def get_connected_nodes_by_openstack_type(ctx, type_name):
-    return [rel.target.node for rel in ctx.instance.relationships
+def get_relationships_by_openstack_type(ctx, type_name):
+    return [rel for rel in ctx.instance.relationships
             if rel.target.instance.runtime_properties.get(
                 OPENSTACK_TYPE_PROPERTY) == type_name]
 
 
+def get_connected_nodes_by_openstack_type(ctx, type_name):
+    return [rel.target.node
+            for rel in get_relationships_by_openstack_type(ctx, type_name)]
+
+
 def get_openstack_ids_of_connected_nodes_by_openstack_type(ctx, type_name):
-    type_caps = [caps for caps in ctx.capabilities.get_all().values() if
-                 caps.get(OPENSTACK_TYPE_PROPERTY) == type_name]
-    return [cap[OPENSTACK_ID_PROPERTY] for cap in type_caps]
+    return [rel.target.instance.runtime_properties[OPENSTACK_ID_PROPERTY]
+            for rel in get_relationships_by_openstack_type(ctx, type_name)
+            ]
 
 
 def get_single_connected_node_by_openstack_type(

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
 
 [testenv:py27]
 deps =
-    coverage==3.7.1 # this fixes issue with tox installing coverage --pre
+    coverage==3.7.1
     nose
     nose-cov
     mock


### PR DESCRIPTION
The NICs list passed to nova.servers.create now is derived from
the server relationships - each is examined, and if it's a relationship
to a network, it's added to the NICs list. If the management network
wasn't found in the relationships list, it's prepended to the NICs list.