### PR TITLE
Test handler doesn't break on None display names in openstack resources

### DIFF
--- a/system_tests/openstack_handler.py
+++ b/system_tests/openstack_handler.py
@@ -630,7 +630,9 @@ class OpenstackHandler(BaseHandler):
                 if self._check_prefix(v.display_name, prefix)]
 
     def _check_prefix(self, name, prefix):
-        return name.startswith(prefix)
+        # some openstack resources (eg. volumes) can have no display_name,
+        # in which case it's None
+        return name is None or name.startswith(prefix)
 
     def _remove_keys(self, dct, keys):
         for key in keys:


### PR DESCRIPTION
Test handler doesn't break on None display names in openstack resources

Some openstack resources (eg. volumes) don't require setting a name,
in which case it's None.
This change makes the system tests cleanup routine handle the resources
with a None name, rather than break on them.
