### PR TITLE
Cfy 5397 add boot volume

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -372,6 +372,9 @@ node_types:
         default: auto
       openstack_config:
         default: {}
+      boot:
+        type: boolean
+        default: false
     interfaces:
       cloudify.interfaces.lifecycle:
         create:


### PR DESCRIPTION
Created boot server from volume feature. Function checks in Server relationships if there is connected Volume node with boot property set True, if such Volume was found function attaches boot Volume external id to server dictionary.

These are minimal changes with unit tests to allow the change. We might add validation of providing image to Volume and removing validation of image on Server.