### PR TITLE
Make OpenStack plugin compatible with keystone version 3

### DIFF
--- a/cinder_plugin/tests/test_volume.py
+++ b/cinder_plugin/tests/test_volume.py
@@ -13,7 +13,6 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-import contextlib
 import mock
 import unittest
 
@@ -22,9 +21,7 @@ from cloudify import exceptions as cfy_exc
 from cloudify.state import current_ctx
 from cinder_plugin import volume
 from nova_plugin import server
-from openstack_plugin_common import (CinderClient,
-                                     NovaClient,
-                                     OPENSTACK_ID_PROPERTY,
+from openstack_plugin_common import (OPENSTACK_ID_PROPERTY,
                                      OPENSTACK_TYPE_PROPERTY,
                                      OPENSTACK_NAME_PROPERTY)
 
@@ -142,7 +139,10 @@ class TestCinderVolume(unittest.TestCase):
         self.assertTrue(OPENSTACK_NAME_PROPERTY
                         not in ctx_m.instance.runtime_properties)
 
-    def test_attach(self):
+    @mock.patch('openstack_plugin_common.NovaClientWithSugar')
+    @mock.patch('openstack_plugin_common.CinderClientWithSugar')
+    @mock.patch.object(volume, 'wait_until_status', return_value=(None, True))
+    def test_attach(self, wait_until_status_m, cinder_m, nova_m):
         volume_id = '00000000-0000-0000-0000-000000000000'
         server_id = '11111111-1111-1111-1111-111111111111'
         device_name = '/dev/fake'
@@ -172,31 +172,23 @@ class TestCinderVolume(unittest.TestCase):
                            target=server_ctx,
                            source=volume_ctx)
 
-        cinderclient_m = mock.Mock()
-        novaclient_m = mock.Mock()
-        novaclient_m.volumes = mock.Mock()
-        novaclient_m.volumes.create_server_volume = mock.Mock()
+        nova_instance = nova_m.return_value
+        cinder_instance = cinder_m.return_value
 
-        with contextlib.nested(
-                mock.patch.object(NovaClient, 'get',
-                                  mock.Mock(return_value=novaclient_m)),
-                mock.patch.object(CinderClient, 'get',
-                                  mock.Mock(return_value=cinderclient_m)),
-                mock.patch.object(volume,
-                                  'wait_until_status',
-                                  mock.Mock(return_value=(None, True)))):
+        server.attach_volume(ctx=ctx_m)
 
-            server.attach_volume(ctx=ctx_m)
+        nova_instance.volumes.create_server_volume.assert_called_once_with(
+            server_id, volume_id, device_name)
+        wait_until_status_m.assert_called_once_with(
+            cinder_client=cinder_instance,
+            volume_id=volume_id,
+            status=volume.VOLUME_STATUS_IN_USE)
 
-            novaclient_m.volumes.create_server_volume.assert_called_once_with(
-                server_id, volume_id, device_name)
-            volume.wait_until_status.assert_called_once_with(
-                cinder_client=cinderclient_m,
-                volume_id=volume_id,
-                status=volume.VOLUME_STATUS_IN_USE)
-
+    @mock.patch('openstack_plugin_common.NovaClientWithSugar')
+    @mock.patch('openstack_plugin_common.CinderClientWithSugar')
     def _test_cleanup__after_attach_fails(
-            self, volume_ctx_mgr, expected_err_cls, expect_cleanup=True):
+            self, expected_err_cls, expect_cleanup,
+            wait_until_status_m, cinder_m, nova_m):
         volume_id = '00000000-0000-0000-0000-000000000000'
         server_id = '11111111-1111-1111-1111-111111111111'
         attachment_id = '22222222-2222-2222-2222-222222222222'
@@ -231,86 +223,60 @@ class TestCinderVolume(unittest.TestCase):
                            target=server_ctx,
                            source=volume_ctx)
 
-        attached_volume_m = mock.Mock()
-        attached_volume_m.id = volume_id
-        attached_volume_m.status = volume.VOLUME_STATUS_IN_USE
-        attached_volume_m.attachments = [attachment]
-        cinderclient_m = mock.Mock()
-        cinderclient_m.volumes = mock.Mock()
-        cinderclient_m.volumes.get = mock.Mock(
-            return_value=attached_volume_m)
-        novaclient_m = mock.Mock()
-        novacl_vols_m = novaclient_m.volumes = mock.Mock()
-        novacl_vols_m.create_server_volume = mock.Mock()
+        attached_volume = mock.Mock(id=volume_id,
+                                    status=volume.VOLUME_STATUS_IN_USE,
+                                    attachments=[attachment])
+        nova_instance = nova_m.return_value
+        cinder_instance = cinder_m.return_value
+        cinder_instance.volumes.get.return_value = attached_volume
 
-        with contextlib.nested(
-                mock.patch.object(NovaClient, 'get',
-                                  mock.Mock(return_value=novaclient_m)),
-                mock.patch.object(CinderClient, 'get',
-                                  mock.Mock(return_value=cinderclient_m)),
-                volume_ctx_mgr):
-            with self.assertRaises(expected_err_cls):
-                server.attach_volume(ctx=ctx_m)
+        with self.assertRaises(expected_err_cls):
+            server.attach_volume(ctx=ctx_m)
 
-            novacl_vols_m.create_server_volume.assert_called_once_with(
-                server_id, volume_id, device_name)
-            volume.wait_until_status.assert_any_call(
-                cinder_client=cinderclient_m,
+        nova_instance.volumes.create_server_volume.assert_called_once_with(
+            server_id, volume_id, device_name)
+        volume.wait_until_status.assert_any_call(
+            cinder_client=cinder_instance,
+            volume_id=volume_id,
+            status=volume.VOLUME_STATUS_IN_USE)
+        if expect_cleanup:
+            nova_instance.volumes.delete_server_volume.assert_called_once_with(
+                server_id, attachment_id)
+            self.assertEqual(2, volume.wait_until_status.call_count)
+            volume.wait_until_status.assert_called_with(
+                cinder_client=cinder_instance,
                 volume_id=volume_id,
-                status=volume.VOLUME_STATUS_IN_USE)
-            if expect_cleanup:
-                novacl_vols_m.delete_server_volume.assert_called_once_with(
-                    server_id, attachment_id)
-                self.assertEqual(2, volume.wait_until_status.call_count)
-                volume.wait_until_status.assert_called_with(
-                    cinder_client=cinderclient_m,
-                    volume_id=volume_id,
-                    status=volume.VOLUME_STATUS_AVAILABLE)
-
-    def _test_cleanup_after_waituntilstatus_throws(self, err, expect_cleanup):
-        def raise_once(*args, **kwargs):
-            if raise_once.first_call:
-                raise_once.first_call = False
-                raise err
-            else:
-                return None, True
-        raise_once.first_call = True
-
-        self._test_cleanup__after_attach_fails(
-            volume_ctx_mgr=mock.patch.object(
-                volume,
-                'wait_until_status',
-                mock.Mock(side_effect=raise_once)
-            ),
-            expected_err_cls=type(err),
-            expect_cleanup=expect_cleanup
-        )
+                status=volume.VOLUME_STATUS_AVAILABLE)
 
     def test_cleanup_after_waituntilstatus_throws_recoverable_error(self):
         err = cfy_exc.RecoverableError('Some recoverable error')
-        self._test_cleanup_after_waituntilstatus_throws(err, True)
+        with mock.patch.object(volume, 'wait_until_status',
+                               side_effect=[err, (None, True)]) as wait_mock:
+            self._test_cleanup__after_attach_fails(type(err), True, wait_mock)
 
     def test_cleanup_after_waituntilstatus_throws_any_not_nonrecov_error(self):
         class ArbitraryNonRecoverableException(Exception):
             pass
         err = ArbitraryNonRecoverableException('An exception')
-        self._test_cleanup_after_waituntilstatus_throws(err, True)
+        with mock.patch.object(volume, 'wait_until_status',
+                               side_effect=[err, (None, True)]) as wait_mock:
+            self._test_cleanup__after_attach_fails(type(err), True, wait_mock)
 
     def test_cleanup_after_waituntilstatus_lets_nonrecov_errors_pass(self):
         err = cfy_exc.NonRecoverableError('Some non recoverable error')
-        self._test_cleanup_after_waituntilstatus_throws(err, False)
+        with mock.patch.object(volume, 'wait_until_status',
+                               side_effect=[err, (None, True)]) as wait_mock:
+            self._test_cleanup__after_attach_fails(type(err), False, wait_mock)
 
-    def test_cleanup_after_waituntilstatus_times_out(self):
-        self._test_cleanup__after_attach_fails(
-            volume_ctx_mgr=mock.patch.object(
-                volume,
-                'wait_until_status',
-                mock.Mock(return_value=(None, False))
-            ),
-            expected_err_cls=cfy_exc.RecoverableError
-        )
+    @mock.patch.object(volume, 'wait_until_status', return_value=(None, False))
+    def test_cleanup_after_waituntilstatus_times_out(self, wait_mock):
+        self._test_cleanup__after_attach_fails(cfy_exc.RecoverableError, True,
+                                               wait_mock)
 
-    def test_detach(self):
+    @mock.patch('openstack_plugin_common.NovaClientWithSugar')
+    @mock.patch('openstack_plugin_common.CinderClientWithSugar')
+    @mock.patch.object(volume, 'wait_until_status', return_value=(None, True))
+    def test_detach(self, wait_until_status_m, cinder_m, nova_m):
         volume_id = '00000000-0000-0000-0000-000000000000'
         server_id = '11111111-1111-1111-1111-111111111111'
         attachment_id = '22222222-2222-2222-2222-222222222222'
@@ -344,31 +310,18 @@ class TestCinderVolume(unittest.TestCase):
                            target=server_ctx,
                            source=volume_ctx)
 
-        attached_volume_m = mock.Mock()
-        attached_volume_m.id = volume_id
-        attached_volume_m.status = volume.VOLUME_STATUS_IN_USE
-        attached_volume_m.attachments = [attachment]
-        cinder_client_m = mock.Mock()
-        cinder_client_m.volumes = mock.Mock()
-        cinder_client_m.volumes.get = mock.Mock(
-            return_value=attached_volume_m)
+        attached_volume = mock.Mock(id=volume_id,
+                                    status=volume.VOLUME_STATUS_IN_USE,
+                                    attachments=[attachment])
+        nova_instance = nova_m.return_value
+        cinder_instance = cinder_m.return_value
+        cinder_instance.volumes.get.return_value = attached_volume
 
-        novaclient_m = mock.Mock()
-        novaclient_m.volumes = mock.Mock()
-        novaclient_m.volumes.delete_server_volume = mock.Mock()
+        server.detach_volume(ctx=ctx_m)
 
-        with contextlib.nested(
-                mock.patch.object(NovaClient, 'get',
-                                  mock.Mock(return_value=novaclient_m)),
-                mock.patch.object(CinderClient, 'get',
-                                  mock.Mock(return_value=cinder_client_m)),
-                mock.patch.object(volume, 'wait_until_status', mock.Mock())):
-
-            server.detach_volume(ctx=ctx_m)
-
-            novaclient_m.volumes.delete_server_volume.assert_called_once_with(
-                server_id, attachment_id)
-            volume.wait_until_status.assert_called_once_with(
-                cinder_client=cinder_client_m,
-                volume_id=volume_id,
-                status=volume.VOLUME_STATUS_AVAILABLE)
+        nova_instance.volumes.delete_server_volume.assert_called_once_with(
+            server_id, attachment_id)
+        volume.wait_until_status.assert_called_once_with(
+            cinder_client=cinder_instance,
+            volume_id=volume_id,
+            status=volume.VOLUME_STATUS_AVAILABLE)

--- a/openstack_plugin_common/tests/openstack_client_tests.py
+++ b/openstack_plugin_common/tests/openstack_client_tests.py
@@ -25,203 +25,581 @@ from cloudify.mocks import MockCloudifyContext
 import openstack_plugin_common as common
 
 
-class OpenstackClientsTests(unittest.TestCase):
+class ConfigTests(unittest.TestCase):
 
-    def test_clients_custom_configuration(self):
-        # tests for clients custom configuration, passed via properties/inputs
+    @mock.patch.dict('os.environ', clear=True)
+    def test__build_config_from_env_variables_empty(self):
+        cfg = common.Config._build_config_from_env_variables()
+        self.assertEqual({}, cfg)
 
-        envars_cfg = {
-            'OS_USERNAME': 'envar-username',
-            'OS_PASSWORD': 'envar-password',
-            'OS_TENANT_NAME': 'envar-tenant-name',
-            'OS_AUTH_URL': 'envar-auth-url'
+    @mock.patch.dict('os.environ', clear=True,
+                     OS_AUTH_URL='test_url')
+    def test__build_config_from_env_variables_single(self):
+        cfg = common.Config._build_config_from_env_variables()
+        self.assertEqual({'auth_url': 'test_url'}, cfg)
+
+    @mock.patch.dict('os.environ', clear=True,
+                     OS_AUTH_URL='test_url',
+                     OS_PASSWORD='pass',
+                     OS_REGION_NAME='region')
+    def test__build_config_from_env_variables_multiple(self):
+        cfg = common.Config._build_config_from_env_variables()
+        self.assertEqual({
+            'auth_url': 'test_url',
+            'password': 'pass',
+            'region_name': 'region',
+        }, cfg)
+
+    @mock.patch.dict('os.environ', clear=True,
+                     OS_INVALID='invalid',
+                     PASSWORD='pass',
+                     os_region_name='region')
+    def test__build_config_from_env_variables_all_ignored(self):
+        cfg = common.Config._build_config_from_env_variables()
+        self.assertEqual({}, cfg)
+
+    @mock.patch.dict('os.environ', clear=True,
+                     OS_AUTH_URL='test_url',
+                     OS_PASSWORD='pass',
+                     OS_REGION_NAME='region',
+                     OS_INVALID='invalid',
+                     PASSWORD='pass',
+                     os_region_name='region')
+    def test__build_config_from_env_variables_extract_valid(self):
+        cfg = common.Config._build_config_from_env_variables()
+        self.assertEqual({
+            'auth_url': 'test_url',
+            'password': 'pass',
+            'region_name': 'region',
+        }, cfg)
+
+    def test_update_config_empty_target(self):
+        target = {}
+        override = {'k1': 'u1'}
+        result = override.copy()
+
+        common.Config.update_config(target, override)
+        self.assertEqual(result, target)
+
+    def test_update_config_empty_override(self):
+        target = {'k1': 'v1'}
+        override = {}
+        result = target.copy()
+
+        common.Config.update_config(target, override)
+        self.assertEqual(result, target)
+
+    def test_update_config_disjoint_configs(self):
+        target = {'k1': 'v1'}
+        override = {'k2': 'u2'}
+        result = target.copy()
+        result.update(override)
+
+        common.Config.update_config(target, override)
+        self.assertEqual(result, target)
+
+    def test_update_config_do_not_remove_empty_from_target(self):
+        target = {'k1': ''}
+        override = {}
+        result = target.copy()
+
+        common.Config.update_config(target, override)
+        self.assertEqual(result, target)
+
+    def test_update_config_no_empty_in_override(self):
+        target = {'k1': 'v1', 'k2': 'v2'}
+        override = {'k1': 'u2'}
+        result = target.copy()
+        result.update(override)
+
+        common.Config.update_config(target, override)
+        self.assertEqual(result, target)
+
+    def test_update_config_all_empty_in_override(self):
+        target = {'k1': '', 'k2': 'v2'}
+        override = {'k1': '', 'k3': ''}
+        result = target.copy()
+
+        common.Config.update_config(target, override)
+        self.assertEqual(result, target)
+
+    def test_update_config_misc(self):
+        target = {'k1': 'v1', 'k2': 'v2'}
+        override = {'k1': '', 'k2': 'u2', 'k3': '', 'k4': 'u4'}
+        result = {'k1': 'v1', 'k2': 'u2', 'k4': 'u4'}
+
+        common.Config.update_config(target, override)
+        self.assertEqual(result, target)
+
+    @mock.patch.object(common.Config, 'update_config')
+    @mock.patch.object(common.Config, '_build_config_from_env_variables',
+                       return_value={})
+    @mock.patch.dict('os.environ', clear=True,
+                     values={common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR:
+                             '/this/should/not/exist.json'})
+    def test_get_missing_static_config_missing_file(self, from_env, update):
+        cfg = common.Config.get()
+        self.assertEqual({}, cfg)
+        from_env.assert_called_once_with()
+        update.assert_not_called()
+
+    @mock.patch.object(common.Config, 'update_config')
+    @mock.patch.object(common.Config, '_build_config_from_env_variables',
+                       return_value={})
+    def test_get_empty_static_config_present_file(self, from_env, update):
+        file_cfg = {'k1': 'v1', 'k2': 'v2'}
+        env_var = common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR
+        file = tempfile.NamedTemporaryFile(delete=False)
+        json.dump(file_cfg, file)
+        file.close()
+
+        with mock.patch.dict('os.environ', {env_var: file.name}, clear=True):
+            common.Config.get()
+
+        os.unlink(file.name)
+        from_env.assert_called_once_with()
+        update.assert_called_once_with({}, file_cfg)
+
+    @mock.patch.object(common.Config, 'update_config')
+    @mock.patch.object(common.Config, '_build_config_from_env_variables',
+                       return_value={'k1': 'v1'})
+    def test_get_present_static_config_empty_file(self, from_env, update):
+        file_cfg = {}
+        env_var = common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR
+        file = tempfile.NamedTemporaryFile(delete=False)
+        json.dump(file_cfg, file)
+        file.close()
+
+        with mock.patch.dict('os.environ', {env_var: file.name}, clear=True):
+            common.Config.get()
+
+        os.unlink(file.name)
+        from_env.assert_called_once_with()
+        update.assert_called_once_with({'k1': 'v1'}, file_cfg)
+
+    @mock.patch.object(common.Config, 'update_config')
+    @mock.patch.object(common.Config, '_build_config_from_env_variables',
+                       return_value={'k1': 'v1'})
+    @mock.patch.dict('os.environ', clear=True,
+                     values={common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR:
+                             '/this/should/not/exist.json'})
+    def test_get_present_static_config_missing_file(self, from_env, update):
+        cfg = common.Config.get()
+        self.assertEqual({'k1': 'v1'}, cfg)
+        from_env.assert_called_once_with()
+        update.assert_not_called()
+
+    @mock.patch.object(common.Config, 'update_config')
+    @mock.patch.object(common.Config, '_build_config_from_env_variables',
+                       return_value={'k1': 'v1'})
+    def test_get_all_present(self, from_env, update):
+        file_cfg = {'k2': 'u2'}
+        env_var = common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR
+        file = tempfile.NamedTemporaryFile(delete=False)
+        json.dump(file_cfg, file)
+        file.close()
+
+        with mock.patch.dict('os.environ', {env_var: file.name}, clear=True):
+            common.Config.get()
+
+        os.unlink(file.name)
+        from_env.assert_called_once_with()
+        update.assert_called_once_with({'k1': 'v1'}, file_cfg)
+
+
+class OpenstackClientTests(unittest.TestCase):
+
+    def test__merge_custom_configuration_no_custom_cfg(self):
+        cfg = {'k1': 'v1'}
+        new = common.OpenStackClient._merge_custom_configuration(cfg, "dummy")
+        self.assertEqual(cfg, new)
+
+    def test__merge_custom_configuration_client_present(self):
+        cfg = {
+            'k1': 'v1',
+            'k2': 'v2',
+            'custom_configuration': {
+                'dummy': {
+                    'k2': 'u2',
+                    'k3': 'u3'
+                }
+            }
         }
+        result = {
+            'k1': 'v1',
+            'k2': 'u2',
+            'k3': 'u3'
+        }
+        bak = cfg.copy()
+        new = common.OpenStackClient._merge_custom_configuration(cfg, "dummy")
+        self.assertEqual(result, new)
+        self.assertEqual(cfg, bak)
 
-        # file config passes custom_configuration too, but it'll get overridden
-        # by the inputs custom_configuration
-        file_cfg = {
+    def test__merge_custom_configuration_client_missing(self):
+        cfg = {
+            'k1': 'v1',
+            'k2': 'v2',
+            'custom_configuration': {
+                'dummy': {
+                    'k2': 'u2',
+                    'k3': 'u3'
+                }
+            }
+        }
+        result = {
+            'k1': 'v1',
+            'k2': 'v2'
+        }
+        bak = cfg.copy()
+        new = common.OpenStackClient._merge_custom_configuration(cfg, "baddy")
+        self.assertEqual(result, new)
+        self.assertEqual(cfg, bak)
+
+    def test__merge_custom_configuration_multi_client(self):
+        cfg = {
+            'k1': 'v1',
+            'k2': 'v2',
+            'custom_configuration': {
+                'dummy': {
+                    'k2': 'u2',
+                    'k3': 'u3'
+                },
+                'bummy': {
+                    'k1': 'z1'
+                }
+            }
+        }
+        result = {
+            'k1': 'z1',
+            'k2': 'v2',
+        }
+        bak = cfg.copy()
+        new = common.OpenStackClient._merge_custom_configuration(cfg, "bummy")
+        self.assertEqual(result, new)
+        self.assertEqual(cfg, bak)
+
+    def test__validate_auth_params_missing(self):
+        with self.assertRaises(NonRecoverableError):
+            common.OpenStackClient._validate_auth_params({})
+
+    def test__validate_auth_params_too_much(self):
+        with self.assertRaises(NonRecoverableError):
+            common.OpenStackClient._validate_auth_params({
+                'auth_url': 'url',
+                'password': 'pass',
+                'username': 'user',
+                'tenant_name': 'tenant',
+                'project_id': 'project_test',
+            })
+
+    def test__validate_auth_params_v2(self):
+        common.OpenStackClient._validate_auth_params({
+            'auth_url': 'url',
+            'password': 'pass',
+            'username': 'user',
+            'tenant_name': 'tenant',
+        })
+
+    def test__validate_auth_params_v3(self):
+        common.OpenStackClient._validate_auth_params({
+            'auth_url': 'url',
+            'password': 'pass',
+            'username': 'user',
+            'project_id': 'project_test',
+            'user_domain_name': 'user_domain',
+        })
+
+    def test__validate_auth_params_v3_mod(self):
+        common.OpenStackClient._validate_auth_params({
+            'auth_url': 'url',
+            'password': 'pass',
+            'username': 'user',
+            'user_domain_name': 'user_domain',
+            'project_name': 'project_test_name',
+            'project_domain_name': 'project_domain',
+        })
+
+    def test__validate_auth_params_skip_insecure(self):
+        common.OpenStackClient._validate_auth_params({
+            'auth_url': 'url',
+            'password': 'pass',
+            'username': 'user',
+            'user_domain_name': 'user_domain',
+            'project_name': 'project_test_name',
+            'project_domain_name': 'project_domain',
+            'insecure': True
+        })
+
+    def test__split_config(self):
+        auth = {'auth_url': 'url', 'password': 'pass'}
+        misc = {'misc1': 'val1', 'misc2': 'val2'}
+        all = dict(auth)
+        all.update(misc)
+
+        a, m = common.OpenStackClient._split_config(all)
+
+        self.assertEqual(auth, a)
+        self.assertEqual(misc, m)
+
+    @mock.patch.object(common, 'loading')
+    @mock.patch.object(common, 'session')
+    def test__authenticate_secure(self, mock_session, mock_loading):
+        auth_params = {'k1': 'v1'}
+        common.OpenStackClient._authenticate(auth_params)
+        loader = mock_loading.get_plugin_loader.return_value
+        loader.load_from_options.assert_called_once_with(k1='v1')
+        auth = loader.load_from_options.return_value
+        mock_session.Session.assert_called_once_with(auth=auth, verify=True)
+
+    @mock.patch.object(common, 'loading')
+    @mock.patch.object(common, 'session')
+    def test__authenticate_secure_explicit(self, mock_session, mock_loading):
+        auth_params = {'k1': 'v1', 'insecure': False}
+        common.OpenStackClient._authenticate(auth_params)
+        loader = mock_loading.get_plugin_loader.return_value
+        loader.load_from_options.assert_called_once_with(k1='v1')
+        auth = loader.load_from_options.return_value
+        mock_session.Session.assert_called_once_with(auth=auth, verify=True)
+
+    @mock.patch.object(common, 'loading')
+    @mock.patch.object(common, 'session')
+    def test__authenticate_insecure(self, mock_session, mock_loading):
+        auth_params = {'k1': 'v1', 'insecure': True}
+        common.OpenStackClient._authenticate(auth_params)
+        loader = mock_loading.get_plugin_loader.return_value
+        loader.load_from_options.assert_called_once_with(k1='v1')
+        auth = loader.load_from_options.return_value
+        mock_session.Session.assert_called_once_with(auth=auth, verify=False)
+
+    @mock.patch.object(common, 'loading')
+    @mock.patch.object(common, 'session')
+    def test__authenticate_secure_misc(self, mock_session, mock_loading):
+        params = {'k1': 'v1'}
+        tests = ('', 'a', [], {}, set(), 4, 0, -1, 3.14, 0.0, None)
+        for test in tests:
+            auth_params = params.copy()
+            auth_params['insecure'] = test
+
+            common.OpenStackClient._authenticate(auth_params)
+            loader = mock_loading.get_plugin_loader.return_value
+            loader.load_from_options.assert_called_with(**params)
+            auth = loader.load_from_options.return_value
+            mock_session.Session.assert_called_with(auth=auth, verify=True)
+
+
+class ClientsConfigTest(unittest.TestCase):
+
+    def setUp(self):
+        file = tempfile.NamedTemporaryFile(delete=False)
+        json.dump(self.get_file_cfg(), file)
+        file.close()
+        self.addCleanup(os.unlink, file.name)
+
+        env_cfg = self.get_env_cfg()
+        env_cfg[common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR] = file.name
+        mock.patch.dict('os.environ', env_cfg, clear=True).start()
+
+        self.loading = mock.patch.object(common, 'loading').start()
+        self.session = mock.patch.object(common, 'session').start()
+        self.nova = mock.patch.object(common, 'nova_client').start()
+        self.neutron = mock.patch.object(common, 'neutron_client').start()
+        self.cinder = mock.patch.object(common, 'cinder_client').start()
+        self.addCleanup(mock.patch.stopall)
+
+        self.loader = self.loading.get_plugin_loader.return_value
+        self.auth = self.loader.load_from_options.return_value
+
+
+class CustomConfigFromInputs(ClientsConfigTest):
+
+    def get_file_cfg(self):
+        return {
             'username': 'file-username',
             'password': 'file-password',
             'tenant_name': 'file-tenant-name',
             'custom_configuration': {
-                'nova_client': {'username': 'custom-username',
-                                'api_key': 'custom-password',
-                                'project_id': 'custom-tenant-name'},
+                'nova_client': {
+                    'username': 'custom-username',
+                    'password': 'custom-password',
+                    'tenant_name': 'custom-tenant-name'
+                },
             }
         }
 
-        inputs_cfg = {
+    def get_inputs_cfg(self):
+        return {
             'username': 'inputs-username',
             'custom_configuration': {
-                'neutron_client': {'password': 'inputs-custom-password'},
-                'cinder_client': {'api_key': 'inputs-custom-password',
-                                  'auth_url': 'inputs-custom-auth-url',
-                                  'extra_key': 'extra-value'},
-                'keystone_client': {'username': 'inputs-custom-username',
-                                    'tenant_name': 'inputs-custom-tenant-name'}
+                'neutron_client': {
+                    'password': 'inputs-custom-password'
+                },
+                'cinder_client': {
+                    'password': 'inputs-custom-password',
+                    'auth_url': 'inputs-custom-auth-url',
+                    'extra_key': 'extra-value'
+                },
             }
         }
 
-        nova_params, neut_params, cind_params, keys_params = \
-            self._create_clients(envars_cfg, file_cfg, inputs_cfg)
-
-        # the first three assertions also check inputs custom-configuration
-        # completely overrides file custom-configuration
-        self.assertEquals('inputs-username', nova_params['username'])
-        self.assertEquals('file-password', nova_params['api_key'])
-        self.assertEquals('file-tenant-name', nova_params['project_id'])
-        self.assertEquals('envar-auth-url', nova_params['auth_url'])
-
-        self.assertEquals('inputs-username', neut_params['username'])
-        self.assertEquals('inputs-custom-password', neut_params['password'])
-        self.assertEquals('file-tenant-name', neut_params['tenant_name'])
-        self.assertEquals('envar-auth-url', neut_params['auth_url'])
-
-        self.assertEquals('inputs-username', cind_params['username'])
-        self.assertEquals('inputs-custom-password', cind_params['api_key'])
-        self.assertEquals('file-tenant-name', cind_params['project_id'])
-        self.assertEquals('inputs-custom-auth-url', cind_params['auth_url'])
-        self.assertEquals('extra-value', cind_params['extra_key'])
-
-        self.assertEquals('inputs-custom-username', keys_params['username'])
-        self.assertEquals('file-password', keys_params['password'])
-        self.assertEquals('inputs-custom-tenant-name',
-                          keys_params['tenant_name'])
-        self.assertEquals('envar-auth-url', keys_params['auth_url'])
-
-    def test_clients_custom_configuration_from_file(self):
-        # tests for clients custom configuration loaded from file
-
-        envars_cfg = {
+    def get_env_cfg(self):
+        return {
             'OS_USERNAME': 'envar-username',
             'OS_PASSWORD': 'envar-password',
             'OS_TENANT_NAME': 'envar-tenant-name',
-            'OS_AUTH_URL': 'envar-auth-url'
+            'OS_AUTH_URL': 'envar-auth-url',
+            common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR: file.name
         }
 
-        file_cfg = {
+    def test_nova(self):
+        common.NovaClientWithSugar(config=self.get_inputs_cfg())
+        self.loader.load_from_options.assert_called_once_with(
+            username='inputs-username',
+            password='file-password',
+            tenant_name='file-tenant-name',
+            auth_url='envar-auth-url'
+        )
+        self.session.Session.assert_called_with(auth=self.auth, verify=True)
+        self.nova.Client.assert_called_once_with(
+            '2', session=self.session.Session.return_value)
+
+    def test_neutron(self):
+        common.NeutronClientWithSugar(config=self.get_inputs_cfg())
+        self.loader.load_from_options.assert_called_once_with(
+            username='inputs-username',
+            password='inputs-custom-password',
+            tenant_name='file-tenant-name',
+            auth_url='envar-auth-url'
+        )
+        self.session.Session.assert_called_with(auth=self.auth, verify=True)
+        self.neutron.Client.assert_called_once_with(
+            session=self.session.Session.return_value)
+
+    def test_cinder(self):
+        common.CinderClientWithSugar(config=self.get_inputs_cfg())
+        self.loader.load_from_options.assert_called_once_with(
+            username='inputs-username',
+            password='inputs-custom-password',
+            tenant_name='file-tenant-name',
+            auth_url='inputs-custom-auth-url'
+        )
+        self.session.Session.assert_called_with(auth=self.auth, verify=True)
+        self.cinder.Client.assert_called_once_with(
+            '2', session=self.session.Session.return_value,
+            extra_key='extra-value')
+
+
+class CustomConfigFromFile(ClientsConfigTest):
+
+    def get_file_cfg(self):
+        return {
             'username': 'file-username',
             'password': 'file-password',
             'tenant_name': 'file-tenant-name',
             'custom_configuration': {
-                'nova_client': {'project_id': 'inputs-custom-tenant-name'},
-                'neutron_client': {'password': 'inputs-custom-password'},
-                'cinder_client': {'api_key': 'inputs-custom-password',
-                                  'auth_url': 'inputs-custom-auth-url',
-                                  'extra_key': 'extra-value'},
-                'keystone_client': {'username': 'inputs-custom-username'}
+                'nova_client': {
+                    'username': 'custom-username',
+                    'password': 'custom-password',
+                    'tenant_name': 'custom-tenant-name'
+                },
             }
         }
 
-        inputs_cfg = {
-            'username': 'inputs-username'
+    def get_inputs_cfg(self):
+        return {
+            'username': 'inputs-username',
         }
 
-        nova_params, neut_params, cind_params, keys_params = \
-            self._create_clients(envars_cfg, file_cfg, inputs_cfg)
+    def get_env_cfg(self):
+        return {
+            'OS_USERNAME': 'envar-username',
+            'OS_PASSWORD': 'envar-password',
+            'OS_TENANT_NAME': 'envar-tenant-name',
+            'OS_AUTH_URL': 'envar-auth-url',
+            common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR: file.name
+        }
 
-        self.assertEquals('inputs-username', nova_params['username'])
-        self.assertEquals('file-password', nova_params['api_key'])
-        self.assertEquals('inputs-custom-tenant-name',
-                          nova_params['project_id'])
-        self.assertEquals('envar-auth-url', nova_params['auth_url'])
+    def test_nova(self):
+        common.NovaClientWithSugar(config=self.get_inputs_cfg())
+        self.loader.load_from_options.assert_called_once_with(
+            username='custom-username',
+            password='custom-password',
+            tenant_name='custom-tenant-name',
+            auth_url='envar-auth-url'
+        )
+        self.session.Session.assert_called_with(auth=self.auth, verify=True)
+        self.nova.Client.assert_called_once_with(
+            '2', session=self.session.Session.return_value)
 
-        self.assertEquals('inputs-username', neut_params['username'])
-        self.assertEquals('inputs-custom-password', neut_params['password'])
-        self.assertEquals('file-tenant-name', neut_params['tenant_name'])
-        self.assertEquals('envar-auth-url', neut_params['auth_url'])
+    def test_neutron(self):
+        common.NeutronClientWithSugar(config=self.get_inputs_cfg())
+        self.loader.load_from_options.assert_called_once_with(
+            username='inputs-username',
+            password='file-password',
+            tenant_name='file-tenant-name',
+            auth_url='envar-auth-url'
+        )
+        self.session.Session.assert_called_with(auth=self.auth, verify=True)
+        self.neutron.Client.assert_called_once_with(
+            session=self.session.Session.return_value)
 
-        self.assertEquals('inputs-username', cind_params['username'])
-        self.assertEquals('inputs-custom-password', cind_params['api_key'])
-        self.assertEquals('file-tenant-name', cind_params['project_id'])
-        self.assertEquals('inputs-custom-auth-url', cind_params['auth_url'])
-        self.assertEquals('extra-value', cind_params['extra_key'])
+    def test_cinder(self):
+        common.CinderClientWithSugar(config=self.get_inputs_cfg())
+        self.loader.load_from_options.assert_called_once_with(
+            username='inputs-username',
+            password='file-password',
+            tenant_name='file-tenant-name',
+            auth_url='envar-auth-url'
+        )
+        self.session.Session.assert_called_with(auth=self.auth, verify=True)
+        self.cinder.Client.assert_called_once_with(
+            '2', session=self.session.Session.return_value)
 
-        self.assertEquals('inputs-custom-username', keys_params['username'])
-        self.assertEquals('file-password', keys_params['password'])
-        self.assertEquals('file-tenant-name', keys_params['tenant_name'])
-        self.assertEquals('envar-auth-url', keys_params['auth_url'])
 
-    def test_input_config_override(self):
+class PutClientInKwTests(unittest.TestCase):
 
-        def perform_test(ctx, openstack_args, key, expected):
-            class ClientClassMock(common.OpenStackClient):
-                result_config = None
+    def test_override_prop_empty_ctx(self):
+        props = {}
+        ctx = MockCloudifyContext(node_id='a20846', properties=props)
+        kwargs = {
+            'ctx': ctx,
+            'openstack_config': {
+                'p1': 'v1'
+            }
+        }
+        expected_cfg = kwargs['openstack_config']
 
-                def get(self, config, **kwargs):
-                    ClientClassMock.result_config = config
-                    return mock.MagicMock()
+        client_class = mock.MagicMock()
+        common._put_client_in_kw('mock_client', client_class, kwargs)
+        client_class.assert_called_once_with(config=expected_cfg)
 
-            kwargs = {'ctx': ctx}
-            if openstack_args:
-                kwargs['openstack_config'] = openstack_args
-            common._put_client_in_kw('mock_client', ClientClassMock, kwargs)
-            self.assertEquals(expected,
-                              ClientClassMock.result_config.get(key, None))
+    def test_override_prop_nonempty_ctx(self):
+        props = {
+            'openstack_config': {
+                'p1': 'u1',
+                'p2': 'u2'
+            }
+        }
+        props_copy = props.copy()
+        ctx = MockCloudifyContext(node_id='a20846', properties=props)
+        kwargs = {
+            'ctx': ctx,
+            'openstack_config': {
+                'p1': 'v1',
+                'p3': 'v3'
+            }
+        }
+        expected_cfg = {
+            'p1': 'v1',
+            'p2': 'u2',
+            'p3': 'v3'
+        }
 
-        node_context = MockCloudifyContext(node_id='a20846', properties={})
-
-        perform_test(node_context, {'ignored_prop': 'ignored-prop'},
-                     'prop', None)
-        perform_test(node_context, {'prop': 'input-property'},
-                     'prop', 'input-property')
-
-        node_context = MockCloudifyContext(node_id='a20847',
-                                           properties={
-                                               'openstack_config': {
-                                                   'prop': 'context-property'
-                                               }
-                                           }
-                                           )
-        perform_test(node_context, None, 'prop', 'context-property')
-        perform_test(node_context, {'prop': 'input-property'},
-                     'prop', 'input-property')
-
+        client_class = mock.MagicMock()
+        common._put_client_in_kw('mock_client', client_class, kwargs)
+        client_class.assert_called_once_with(config=expected_cfg)
         # Making sure that _put_client_in_kw will not modify
         # 'openstack_config' property of a node.
-        self.assertEquals('context-property',
-                          node_context.node.properties.get(
-                              'openstack_config').get('prop'))
-
-    def _create_clients(self, envars_cfg, file_cfg, inputs_cfg):
-        client_init_args = []
-
-        def client_mock(**kwargs):
-            client_init_args.append(kwargs)
-            return mock.MagicMock()
-
-        orig_nova_client = common.NovaClientWithSugar
-        orig_neut_client = common.NeutronClientWithSugar
-        orig_cind_client = common.CinderClientWithSugar
-        orig_keys_client = common.KeystoneClientWithSugar
-
-        try:
-            common.NovaClientWithSugar = client_mock
-            common.NeutronClientWithSugar = client_mock
-            common.CinderClientWithSugar = client_mock
-            common.KeystoneClientWithSugar = client_mock
-
-            # envars config
-            os.environ.update(envars_cfg)
-
-            # file config
-            conf_file_path = tempfile.mkstemp()[1]
-            os.environ[common.Config.OPENSTACK_CONFIG_PATH_ENV_VAR] = \
-                conf_file_path
-            with open(conf_file_path, 'w') as f:
-                json.dump(file_cfg, f)
-
-            common.NovaClient().get(config=inputs_cfg)
-            common.NeutronClient().get(config=inputs_cfg)
-            common.CinderClient().get(config=inputs_cfg)
-            common.KeystoneClient().get(config=inputs_cfg)
-
-            return client_init_args  # nova, neut, cind, keys
-        finally:
-            common.NovaClientWithSugar = orig_nova_client
-            common.NeutronClientWithSugar = orig_neut_client
-            common.CinderClientWithSugar = orig_cind_client
-            common.KeystoneClientWithSugar = orig_keys_client
+        self.assertEqual(props_copy, ctx.node.properties)
 
 
 class ResourceQuotaTests(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,12 @@ setup(
     description='Cloudify plugin for OpenStack infrastructure.',
     install_requires=[
         'cloudify-plugins-common>=3.3.1',
-        'python-novaclient==2.26.0',
-        'python-keystoneclient==1.6.0',
-        'python-neutronclient==2.6.0',
-        'python-cinderclient==1.2.2',
+        'keystoneauth1==2.12.1',
+        'python-novaclient==6.0.0',
+        'python-keystoneclient==3.5.0',
+        'python-neutronclient==6.0.0',
+        'python-cinderclient==1.9.0',
         'python-glanceclient==2.5.0',
-        'keystoneauth1',
         'IPy==0.81'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist=flake8,docs,py27
 
 [testenv]
+whitelist_externals = make
 deps =
     -rdev-requirements.txt
 


### PR DESCRIPTION
## Goal

Main goal of this pull request is making OpenStack plugin support keystone authentication version 3 without breaking compatibility with older versions of OpenStack.
### Changes in package versions and required packages

While making changes, we bumped OpenStack related packages' versions to their latest stable release. We also added new dependency, `keystoneauth`, that handles OpenStack authentication.
### Class reorganization

Since upstream do not support subclassing clients, we moved client classes around a bit. We made `OpenStackClient` base class for all sugared clients and make it wrap native OpenStack clients. This change enabled us to remove various classes that created sugared clients (eg. `NovaClient`, `CinderClient` ...).
### Authentication changes

We centralized authentication around `keystoneauth` methods. This makes it possible to support different versions of authentication without any additional code. As long as sensible set of parameters is passed in, authentication will work.
## Issues

There are some issues when it comes to using this plugin with the rest of the packages from Cloudify family. Hiccups and solutions to issues encountered while using this plugin version are listed below.
### Bootstraping

New versions of OpenStack related packages mandate use of `requests=2.10.0` package. This version collides with `requests==2.7.0` requested by `clodudify` package, which makes it a bit challenging to bootstrap manager using this version of plugin. Proper solution would probably be to sync versions of `requests` package. Quick fix for this issue is to execute bootstrap procedure in three steps:
1. Install `cloudify` package.
2. Execute `cfy local install-plugins -p path/to/openstack-blueprint.yaml`.
3. Reinstall `cloudify` package.

This fix relies on the fact that OpenStack related plugins still work with a `requests==2.7.0`.
### Cloudify manager bootstrap blueprint

Another issue related to bootstrap procedure is lack of blueprint that would support specifying authentication parameters for keystone version 3. There is a [forked repository](https://github.com/dice-project/cloudify-manager-blueprints/tree/feature/keystoneauth) that contains updated blueprint. If this pull request gets accepted, we can start integrating those changes too.
