### PR TITLE
OPENSTACK-101 Fix loading auth_url from file/env

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,5 @@
+2.0.1:
+    - Fix loading auth_url from environment (OPENSTACK-101)
 2.0:
     - Don't require a Server image to be specified if a boot_volume is attached
     - Add support for keystone auth v3. auth_url setting must now include version

--- a/openstack_plugin_common/__init__.py
+++ b/openstack_plugin_common/__init__.py
@@ -433,11 +433,11 @@ class OpenStackClient(object):
 
     def __init__(self, client_name, client_class, config=None, *args, **kw):
         cfg = Config.get()
-        v3 = '/v3' in config['auth_url']
 
         if config:
             Config.update_config(cfg, config)
 
+        v3 = '/v3' in cfg['auth_url']
         # Newer libraries expect the region key to be `region_name`, not
         # `region`.
         region = cfg.pop('region', None)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,9 +5,9 @@
 plugins:
   openstack:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-openstack-plugin/archive/2.0.zip
+    source: https://github.com/cloudify-cosmo/cloudify-openstack-plugin/archive/2.0.1.zip
     package_name: cloudify-openstack-plugin
-    package_version: '2.0'
+    package_version: '2.0.1'
 
 node_types:
   cloudify.openstack.nodes.Server:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 setup(
     zip_safe=True,
     name='cloudify-openstack-plugin',
-    version='2.0',
+    version='2.0.1',
     author='idanmo',
     author_email='idan@gigaspaces.com',
     packages=[


### PR DESCRIPTION
I assume this will become 2.0.1. Should I update the version numbers to match in the same commit?