### PR TITLE
OPENSTACK-102 no networks raises an error in server start

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 2.0.1:
     - Fix loading auth_url from environment (OPENSTACK-101)
+    - Raise an error if server is not attached to a network. Previously an IndexError would be raised.
 2.0:
     - Don't require a Server image to be specified if a boot_volume is attached
     - Add support for keystone auth v3. auth_url setting must now include version

--- a/nova_plugin/server.py
+++ b/nova_plugin/server.py
@@ -472,17 +472,26 @@ def get_server_by_context(nova_client):
 
 
 def _set_network_and_ip_runtime_properties(server):
+
     ips = {}
-    _, default_network_ips = server.networks.items()[0]
+
+    if not server.networks:
+        raise NonRecoverableError(
+            'The server was created but not attached to a network. '
+            'Cloudify requires that a server is connected to '
+            'at least one port.'
+        )
+
     manager_network_ip = None
     management_network_name = server.metadata.get(
         'cloudify_management_network_name')
+
     for network, network_ips in server.networks.items():
-        if management_network_name and network == management_network_name:
-            manager_network_ip = network_ips[0]
+        if (management_network_name and
+                network == management_network_name) or not \
+                manager_network_ip:
+            manager_network_ip = next(iter(network_ips or []), None)
         ips[network] = network_ips
-    if manager_network_ip is None:
-        manager_network_ip = default_network_ips[0]
     ctx.instance.runtime_properties[NETWORKS_PROPERTY] = ips
     # The ip of this instance in the management network
     ctx.instance.runtime_properties[IP_PROPERTY] = manager_network_ip


### PR DESCRIPTION
But maybe we shouldn't require servers to be connected to networks?