### PR TITLE
OPENSTACK-108 fix missed `volume.display_name`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
     - Don't overwrite server['image'] when server is booted from volume
     - Fix loading auth_url from environment (OPENSTACK-101)
     - Raise an error if server is not attached to a network. Previously an IndexError would be raised.
+    - Fix attempt to access `volume.display_name` (is now .name) (OPENSTACK-108)
 2.0:
     - Don't require a Server image to be specified if a boot_volume is attached
     - Add support for keystone auth v3. auth_url setting must now include version

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ checkout:
 
 dependencies:
   override:
-    - pip install tox
+    - pip install --upgrade tox virtualenv
 
 test:
   override:

--- a/openstack_plugin_common/__init__.py
+++ b/openstack_plugin_common/__init__.py
@@ -837,7 +837,7 @@ class CinderClientWithSugar(OpenStackClient):
         return resource.id
 
     def get_name_from_resource(self, resource):
-        return resource.display_name
+        return resource.name
 
     def get_quota(self, obj_type_single):
         # we're already authenticated, but the following call will make

--- a/openstack_plugin_common/tests/openstack_client_tests.py
+++ b/openstack_plugin_common/tests/openstack_client_tests.py
@@ -416,6 +416,15 @@ class OpenstackClientTests(unittest.TestCase):
             auth = loader.load_from_options.return_value
             mock_session.Session.assert_called_with(auth=auth, verify=True)
 
+    @mock.patch.object(common, 'cinder_client')
+    def test_cinder_client_get_name_from_resource(self, cc_mock):
+        ccws = common.CinderClientWithSugar()
+        mock_volume = mock.Mock()
+
+        self.assertIs(
+            mock_volume.name,
+            ccws.get_name_from_resource(mock_volume))
+
 
 class ClientsConfigTest(unittest.TestCase):
 

--- a/system_tests/openstack_handler.py
+++ b/system_tests/openstack_handler.py
@@ -20,8 +20,9 @@ import time
 import copy
 from contextlib import contextmanager
 
-from cinderclient.v1 import client as cinderclient
-import novaclient.v2.client as nvclient
+from cinderclient import client as cinderclient
+from keystoneauth1 import loading, session
+import novaclient.client as nvclient
 import neutronclient.v2_0.client as neclient
 from retrying import retry
 
@@ -249,13 +250,21 @@ class OpenstackHandler(BaseHandler):
 
     def openstack_clients(self):
         creds = self._client_creds()
-        return (nvclient.Client(**creds),
-                neclient.Client(username=creds['username'],
-                                password=creds['api_key'],
-                                tenant_name=creds['project_id'],
-                                region_name=creds['region_name'],
-                                auth_url=creds['auth_url']),
-                cinderclient.Client(**creds))
+        params = {
+            'region_name': creds.pop('region_name'),
+        }
+
+        loader = loading.get_plugin_loader("password")
+        auth = loader.load_from_options(**creds)
+        sess = session.Session(auth=auth, verify=True)
+
+        params['session'] = sess
+
+        nova = nvclient.Client('2', **params)
+        neutron = neclient.Client(**params)
+        cinder = cinderclient.Client('2', **params)
+
+        return (nova, neutron, cinder)
 
     @retry(stop_max_attempt_number=5, wait_fixed=20000)
     def openstack_infra_state(self):
@@ -489,7 +498,7 @@ class OpenstackHandler(BaseHandler):
                 try:
                     self.logger.info('Detaching volume {0} ({1}), currently in'
                                      ' status {2} ...'.
-                                     format(volume.display_name, volume.id,
+                                     format(volume.name, volume.id,
                                             volume.status))
                     for attachment in volume.attachments:
                         nova.volumes.delete_server_volume(
@@ -498,7 +507,7 @@ class OpenstackHandler(BaseHandler):
                 except Exception as e:
                     self.logger.warning('Attempt to detach volume {0} ({1})'
                                         ' yielded exception: "{2}"'.
-                                        format(volume.display_name, volume.id,
+                                        format(volume.name, volume.id,
                                                e))
                     unremovables[volume.id] = e
                     existing_volumes.remove(volume)
@@ -510,13 +519,13 @@ class OpenstackHandler(BaseHandler):
                 try:
                     self.logger.info('Deleting volume {0} ({1}), currently in'
                                      ' status {2} ...'.
-                                     format(volume.display_name, volume.id,
+                                     format(volume.name, volume.id,
                                             volume.status))
                     cinder.volumes.delete(volume)
                 except Exception as e:
                     self.logger.warning('Attempt to delete volume {0} ({1})'
                                         ' yielded exception: "{2}"'.
-                                        format(volume.display_name, volume.id,
+                                        format(volume.name, volume.id,
                                                e))
                     unremovables[volume.id] = e
                     existing_volumes.remove(volume)
@@ -526,7 +535,7 @@ class OpenstackHandler(BaseHandler):
             time.sleep(3)
             for volume in existing_volumes:
                 volume_id = volume.id
-                volume_name = volume.display_name
+                volume_name = volume.name
                 try:
                     vol = cinder.volumes.get(volume_id)
                     if vol.status == 'deleting':
@@ -564,7 +573,7 @@ class OpenstackHandler(BaseHandler):
 
                 unremovables[volume.id] = 'timed out while removing volume '\
                                           '{0} ({1}), current volume status '\
-                                          'is {2}'.format(volume.display_name,
+                                          'is {2}'.format(volume.name,
                                                           volume.id,
                                                           vol_status)
 
@@ -577,9 +586,9 @@ class OpenstackHandler(BaseHandler):
     def _client_creds(self):
         return {
             'username': self.env.keystone_username,
-            'api_key': self.env.keystone_password,
+            'password': self.env.keystone_password,
             'auth_url': self.env.keystone_url,
-            'project_id': self.env.keystone_tenant_name,
+            'project_name': self.env.keystone_tenant_name,
             'region_name': self.env.region
         }
 
@@ -623,8 +632,8 @@ class OpenstackHandler(BaseHandler):
                 if self._check_prefix(p['name'], prefix)]
 
     def _volumes(self, cinder, prefix):
-        return [(v.id, v.display_name) for v in cinder.volumes.list()
-                if self._check_prefix(v.display_name, prefix)]
+        return [(v.id, v.name) for v in cinder.volumes.list()
+                if self._check_prefix(v.name, prefix)]
 
     def _check_prefix(self, name, prefix):
         # some openstack resources (eg. volumes) can have no display_name,

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,14 @@ deps =
     mock
     testfixtures
     {[testenv]deps}
-commands = nosetests --with-cov --cov cinder_plugin --cov nova_plugin --cov glance_plugin --cov nova_plugin --cov neutron_plugin --cov openstack_plugin_common cinder_plugin/tests nova_plugin/tests glance_plugin/tests neutron_plugin/tests/test_port.py openstack_plugin_common/tests/openstack_client_tests.py  keystone_plugin/tests/
+commands =
+    nosetests --with-cov --cov-report term-missing \
+    --cov cinder_plugin cinder_plugin/tests \
+    --cov glance_plugin glance_plugin/tests \
+    --cov keystone_plugin keystone_plugin/tests \
+    --cov neutron_plugin neutron_plugin/tests/test_port.py \
+    --cov nova_plugin nova_plugin/tests \
+    --cov openstack_plugin_common openstack_plugin_common/tests
 
 [testenv:docs]
 changedir=docs


### PR DESCRIPTION
(cinderclient 1.9 changed it to `volume.name`)