### PR TITLE
Adding ability to setup server groups on servers using Cloudify OpenStack plugin

### DIFF
--- a/nova_plugin/server.py
+++ b/nova_plugin/server.py
@@ -53,6 +53,7 @@ from openstack_plugin_common import (
     COMMON_RUNTIME_PROPERTIES_KEYS,
     with_neutron_client)
 from nova_plugin.keypair import KEYPAIR_OPENSTACK_TYPE
+from nova_plugin.server_group import SERVER_GROUP_OPENSTACK_TYPE
 from nova_plugin import userdata
 from openstack_plugin_common.floatingip import (IP_ADDRESS_PROPERTY,
                                                 get_server_floating_ip)
@@ -331,6 +332,14 @@ def create(nova_client, neutron_client, args, **kwargs):
         'server')
 
     _prepare_server_nics(neutron_client, ctx, server)
+
+    # server group handling
+    server_group_id = get_openstack_id_of_single_connected_node_by_openstack_type(
+        ctx, SERVER_GROUP_OPENSTACK_TYPE, True)
+    if server_group_id:
+        scheduler_hints = server.get('scheduler_hints', {})
+        scheduler_hints['group'] = server_group_id
+        server['scheduler_hints'] = scheduler_hints
 
     ctx.logger.debug(
         "server.create() server after transformations: {0}".format(server))

--- a/nova_plugin/server_group.py
+++ b/nova_plugin/server_group.py
@@ -1,0 +1,77 @@
+#########
+# Copyright (c) 2014 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+from cloudify import ctx
+from cloudify.decorators import operation
+from openstack_plugin_common import (
+    with_nova_client,
+    validate_resource,
+    use_external_resource,
+    transform_resource_name,
+    is_external_resource,
+    delete_runtime_properties,
+    get_resource_id,
+    OPENSTACK_ID_PROPERTY,
+    OPENSTACK_TYPE_PROPERTY,
+    OPENSTACK_NAME_PROPERTY,
+    COMMON_RUNTIME_PROPERTIES_KEYS
+)
+
+RUNTIME_PROPERTIES_KEYS = COMMON_RUNTIME_PROPERTIES_KEYS
+SERVER_GROUP_OPENSTACK_TYPE = 'server_group'
+
+
+@operation
+@with_nova_client
+def create(nova_client, args, **kwargs):
+
+    if use_external_resource(ctx, nova_client, SERVER_GROUP_OPENSTACK_TYPE):
+        return
+
+    server_grp = {
+        'name': get_resource_id(ctx, SERVER_GROUP_OPENSTACK_TYPE),
+        'policies': [ctx.node.properties['policy']]
+    }
+    transform_resource_name(ctx, server_grp)
+
+    server_grp = nova_client.server_groups.create(**server_grp)
+    ctx.instance.runtime_properties[OPENSTACK_ID_PROPERTY] = server_grp.id
+    ctx.instance.runtime_properties[OPENSTACK_TYPE_PROPERTY] = \
+        SERVER_GROUP_OPENSTACK_TYPE
+    ctx.instance.runtime_properties[OPENSTACK_NAME_PROPERTY] = server_grp.name
+
+
+@operation
+@with_nova_client
+def delete(nova_client, **kwargs):
+    if not is_external_resource(ctx):
+        ctx.logger.info('deleting server group')
+
+        nova_client.server_groups.delete(
+            ctx.instance.runtime_properties[OPENSTACK_ID_PROPERTY])
+    else:
+        ctx.logger.info('not deleting server group since an external server '
+                        'group is being used')
+
+    delete_runtime_properties(ctx, RUNTIME_PROPERTIES_KEYS)
+
+
+@operation
+@with_nova_client
+def creation_validation(nova_client, **kwargs):
+
+    validate_resource(ctx, nova_client, SERVER_GROUP_OPENSTACK_TYPE)
+
+    ctx.logger.debug('OK: server group configuration is valid')

--- a/openstack_plugin_common/__init__.py
+++ b/openstack_plugin_common/__init__.py
@@ -815,7 +815,7 @@ class NovaClientWithSugar(OpenStackClient):
             config['endpoint_override'] = config.pop('nova_url')
 
         super(NovaClientWithSugar, self).__init__(
-            'nova_client', partial(nova_client.Client, '2'), *args, **kw)
+            'nova_client', partial(nova_client.Client, '2.15'), *args, **kw)
 
     def cosmo_list(self, obj_type_single, **kw):
         """ Sugar for xxx.findall() - not using xxx.list() because findall

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -578,13 +578,13 @@ node_types:
               description: >
                 Number of times to check for the creation's status before failing
               type: integer
-              default: 20 
+              default: 20
             status_timeout:
               description: >
                 Interval (in seconds) between subsequent inquiries of the creation's
                 status
               type: integer
-              default: 15 
+              default: 15
         delete:
           implementation: openstack.cinder_plugin.volume.delete
           inputs:
@@ -822,6 +822,61 @@ node_types:
       cloudify.interfaces.validation:
         creation: openstack.keystone_plugin.project.creation_validation
 
+  cloudify.openstack.nodes.ServerGroup:
+    derived_from: cloudify.nodes.Root
+    properties:
+      policy:
+        type: string
+        description: >
+          the policy of the server group, this must be either 'affinity',
+          'anti-affinity', 'soft-affinity', or 'soft-anti-affinity'.
+      use_external_resource:
+        type: boolean
+        default: false
+        description: >
+          a boolean describing whether this resource should be
+          created or rather that it already exists on Openstack
+          and should be used as-is.
+      create_if_missing:
+        default: false
+        description: >
+          If use_external_resource is ``true`` and the resource is missing,
+          create it instead of failing.
+      resource_id:
+        default: ''
+        description: >
+          the name that will be given to the resource on Openstack (excluding optional prefix).
+          If not provided, a default name will be given instead.
+          If use_external_resource is set to "true", this exact
+          value (without any prefixes applied) will be looked for
+          as either the name or id of an existing server group to be used.
+      openstack_config:
+        default: {}
+        description: >
+          endpoints and authentication configuration for Openstack.
+          Expected to contain the following nested fields:
+          username, password, tenant_name, auth_url, region.
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: openstack.nova_plugin.server_group.create
+          inputs:
+            args:
+              default: {}
+            openstack_config:
+              default: {}
+        delete:
+          implementation: openstack.nova_plugin.server_group.delete
+          inputs:
+            openstack_config:
+              default: {}
+      cloudify.interfaces.validation:
+        creation:
+          implementation: openstack.nova_plugin.server_group.creation_validation
+          inputs:
+            openstack_config:
+              default: {}
+
 relationships:
   cloudify.openstack.port_connected_to_security_group:
     derived_from: cloudify.relationships.connected_to
@@ -951,3 +1006,6 @@ relationships:
                 status
               type: integer
               default: 2
+
+  cloudify.openstack.server_connected_to_server_group:
+    derived_from: cloudify.relationships.connected_to


### PR DESCRIPTION
This is a fix for https://cloudifysource.atlassian.net/browse/CFY-7487.

This involves the following changes:

 - adds a new server group module to allow manipulating server groups
 - changes to allow assigning server groups at server creation
 - updates the OpenStack client API version to use 2.15 (this is required in order to support "soft-anti-affinity")
