### PR TITLE
Get neutron project quota fix

### DIFF
--- a/keystone_plugin/project.py
+++ b/keystone_plugin/project.py
@@ -129,13 +129,14 @@ def validate_users(users, keystone_client, **kwargs):
 
 def get_quota(tenant_id, client, what_quota):
     if what_quota == NEUTRON:
-        quota = client.get_quotas_tenant(tenant=tenant_id)
-        return quota
+        quota = dict(client.show_quota(tenant_id=tenant_id)).get('quota')
     else:
-        quota = client.quotas.get(tenant_id=tenant_id)
+        quota = client.quotas.get(tenant_id=tenant_id).to_dict()
+
     ctx.logger.debug(
         'Got {0} quota: {1}'.format(what_quota, str(quota)))
-    return quota.to_dict()
+
+    return quota
 
 
 def update_quota(tenant_id, quota, client, what_quota):


### PR DESCRIPTION
To get neutron quota for a project 'client.get_quotas_tenant' had been called. The result was dictionary with only one entry containing tenant_id. Now show_quota method is used to get proper values of neutron quota.