### PR TITLE
Fixes #220: Correcting the parameter passing order to the method 'set…

### DIFF
--- a/nova_plugin/keypair.py
+++ b/nova_plugin/keypair.py
@@ -69,7 +69,7 @@ def create(nova_client, args, **kwargs):
     keypair = nova_client.keypairs.create(keypair['name'],
                                           keypair.get('public_key'))
 
-    set_openstack_runtime_properties(ctx, KEYPAIR_OPENSTACK_TYPE, keypair)
+    set_openstack_runtime_properties(ctx, keypair, KEYPAIR_OPENSTACK_TYPE)
 
     try:
         # write private key file


### PR DESCRIPTION
This patch corrects the parameter passing order to the method 'set_openstack_runtime_properties'.

This resolves the Issue: Keypair creation failing with 'str' object has no attribute 'id' error #220
https://github.com/cloudify-cosmo/cloudify-openstack-plugin/issues/220