### PR TITLE
Support volume resource_id as create input

### DIFF
--- a/cinder_plugin/volume.py
+++ b/cinder_plugin/volume.py
@@ -26,6 +26,7 @@ from openstack_plugin_common import (delete_resource_and_runtime_properties,
                                      add_list_to_runtime_properties,
                                      create_object_dict,
                                      COMMON_RUNTIME_PROPERTIES_KEYS,
+                                     RESOURCE_ID_RUNTIME_PROPERTY,
                                      OPENSTACK_AZ_PROPERTY,
                                      OPENSTACK_ID_PROPERTY,
                                      OPENSTACK_TYPE_PROPERTY,
@@ -52,7 +53,10 @@ RUNTIME_PROPERTIES_KEYS = COMMON_RUNTIME_PROPERTIES_KEYS
 
 @operation
 @with_cinder_client
-def create(cinder_client, status_attempts, status_timeout, args, **kwargs):
+def create(cinder_client, status_attempts, status_timeout, args,
+           resource_id=None, **kwargs):
+    ctx.instance.runtime_properties[RESOURCE_ID_RUNTIME_PROPERTY] = resource_id
+    ctx.instance.update()
 
     if use_external_resource(ctx, cinder_client, VOLUME_OPENSTACK_TYPE,
                              'name'):

--- a/openstack_plugin_common/__init__.py
+++ b/openstack_plugin_common/__init__.py
@@ -43,6 +43,7 @@ INFINITE_RESOURCE_QUOTA = -1
 USE_EXTERNAL_RESOURCE_PROPERTY = 'use_external_resource'
 CREATE_IF_MISSING_PROPERTY = 'create_if_missing'
 CONFIG_PROPERTY = 'openstack_config'
+RESOURCE_ID = 'resource_id'
 
 # runtime properties
 OPENSTACK_AZ_PROPERTY = 'availability_zone'
@@ -52,6 +53,7 @@ OPENSTACK_NAME_PROPERTY = 'external_name'  # resource's openstack name
 CONDITIONALLY_CREATED = 'conditionally_created'  # resource was
 # conditionally created
 CONFIG_RUNTIME_PROPERTY = CONFIG_PROPERTY   # openstack configuration
+RESOURCE_ID_RUNTIME_PROPERTY = 'resource_id'
 
 # operation inputs
 CONFIG_INPUT = CONFIG_PROPERTY
@@ -325,7 +327,9 @@ def transform_resource_name(ctx, res):
 
 def _get_resource_by_name_or_id_from_ctx(ctx, name_field_name, openstack_type,
                                          sugared_client):
-    resource_id = ctx.node.properties['resource_id']
+    resource_id = ctx.node.properties[RESOURCE_ID] \
+        or ctx.instance.runtime_properties.get(RESOURCE_ID_RUNTIME_PROPERTY)
+
     if not resource_id:
         raise NonRecoverableError(
             "Can't set '{0}' to True without supplying a value for "

--- a/openstack_plugin_common/tests/openstack_client_tests.py
+++ b/openstack_plugin_common/tests/openstack_client_tests.py
@@ -762,9 +762,11 @@ class UseExternalResourceTests(unittest.TestCase):
         else:
             runtime_properties['resource_id'] = 'resource_id'
 
-        node_context = MockCloudifyContext(node_id='a20847',
-                                           properties=properties,
-                                           runtime_properties=runtime_properties)
+        node_context = MockCloudifyContext(
+            node_id='a20847',
+            properties=properties,
+            runtime_properties=runtime_properties)
+
         with mock.patch(
                 'openstack_plugin_common.get_resource_by_name_or_id',
                 new=return_value):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -823,6 +823,11 @@ node_types:
                 status
               type: integer
               default: 15
+            resource_id:
+              type: string
+              default: ''
+              description: >
+                name to give to the new resource or the name or ID of an existing resource when the ``use_external_resource`` property is set to ``true`` (see the using existing resources section). Defaults to '' (empty string).
         delete:
           implementation: openstack.cinder_plugin.volume.delete
           inputs:


### PR DESCRIPTION
Add support for setting a volume's `resource_id` during creation. We can already already do similar for the `name`, but the `resource_id` is needed to get it working with `create_if_missing`.