### PR TITLE
Conditionally created resources are deleted

### DIFF
--- a/openstack_plugin_common/__init__.py
+++ b/openstack_plugin_common/__init__.py
@@ -452,7 +452,7 @@ def delete_resource_and_runtime_properties(ctx, sugared_client,
                                            runtime_properties_keys):
     node_openstack_type = ctx.instance.runtime_properties[
         OPENSTACK_TYPE_PROPERTY]
-    if not is_external_resource(ctx):
+    if not is_external_resource_not_conditionally_created(ctx):
         ctx.logger.info('deleting {0}'.format(node_openstack_type))
         sugared_client.cosmo_delete_resource(
             node_openstack_type,


### PR DESCRIPTION
This change is related to situation when we have in blueprint some openstack resource defined with:
1) "use_external_resource" set to true
2) "create_if_missing" set to true
3) resource doesn't exist on Openstack

In this case expected behaviour of **create** operation will be:
* check if resource exists on Openstack
* detect that resource doesn't exist on Openstack
* create new resource
* set flag CREATED_CONDITIONALLY in runtime_properties

This part works properly.

**delete** operation should ***probably*** delete resource when:
* use_external_resource == false
or
* use_external_resource == true and resource has been created conditionally by the same blueprint (flag CREATED_CONDITIONALLY set in runtime_properties)

For now checking if resource has been created conditionally by the same blueprint was skipped in common delete method. So, resources created conditionally by blueprint were note removed during uninstallation.

It caused an issue in one of customer projects. We had conditionally created router  with external network assigned using relationship. During deletion router hasn't been delete and when Cloudify tried to delete network execution had failed (because network was still plugged into router).

I suppose that keeping current deletion logic may be a source of similar issues in the future, so I proposed this change.