### PR TITLE
Flavor access and flavor extra-specs support added

### DIFF
--- a/blueprints/flavor.yaml
+++ b/blueprints/flavor.yaml
@@ -1,0 +1,56 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - http://www.getcloudify.org/spec/cloudify/4.2/types.yaml
+  - http://www.getcloudify.org/spec/openstack-plugin/2.9.9/plugin.yaml
+
+inputs:
+  keystone_username:
+    default: { get_secret: keystone_username }
+
+  keystone_password:
+    default: { get_secret: keystone_password }
+
+  keystone_tenant_name:
+    default: { get_secret: keystone_tenant_name }
+
+  keystone_url:
+    default: { get_secret: keystone_url }
+
+  region:
+    default: { get_secret: region }
+
+  flavor:
+    default:
+      vcpus: 4
+      ram: 4096
+      disk: 40
+      swap: 0
+      ephemeral: 0
+      is_public: false
+
+  flavor_extra_spec:
+    default:
+      "hw:cpu_policy": 'dedicated'
+      "hw:cpu_threads_policy": 'isolate'
+
+  flavor_tenants:
+    default: ['cfy_test_project']
+
+dsl_definitions:
+  openstack_config: &openstack_config
+    username: { get_input: keystone_username }
+    password: { get_input: keystone_password }
+    tenant_name: { get_input: keystone_tenant_name }
+    auth_url: { get_input: keystone_url }
+    region: { get_input: region }
+
+node_templates:
+  test_flavor:
+    type: cloudify.openstack.nodes.Flavor
+    properties:
+      flavor: { get_input: flavor }
+      extra_specs: { get_input: flavor_extra_spec }
+      tenants: { get_input: flavor_tenants }
+      resource_id: 'cfy_test_flavor'
+      openstack_config: *openstack_config

--- a/nova_plugin/flavor.py
+++ b/nova_plugin/flavor.py
@@ -16,17 +16,51 @@
 from cloudify import ctx
 from cloudify.decorators import operation
 
-from openstack_plugin_common import (with_nova_client,
-                                     use_external_resource,
-                                     delete_resource_and_runtime_properties,
-                                     create_object_dict,
-                                     add_list_to_runtime_properties,
-                                     set_openstack_runtime_properties,
-                                     COMMON_RUNTIME_PROPERTIES_KEYS)
+from openstack_plugin_common import (
+    with_nova_client,
+    use_external_resource,
+    delete_runtime_properties,
+    delete_resource_and_runtime_properties,
+    create_object_dict,
+    add_list_to_runtime_properties,
+    set_openstack_runtime_properties,
+    COMMON_RUNTIME_PROPERTIES_KEYS
+)
 
 FLAVOR_OPENSTACK_TYPE = 'flavor'
 
+EXTRA_SPECS_PROPERTY = 'extra_specs'
+
+TENANTS_PROPERTY = 'tenants'
+
 RUNTIME_PROPERTIES_KEYS = COMMON_RUNTIME_PROPERTIES_KEYS
+
+
+def _set_extra_specs(ctx, flavor):
+    extra_specs = ctx.node.properties.get(EXTRA_SPECS_PROPERTY, {})
+
+    if extra_specs:
+        ctx.logger.info(
+            'Setting extra specs: {0} for flavor: {1}'
+            .format(extra_specs, flavor.to_dict())
+        )
+
+        flavor.set_keys(extra_specs)
+
+    ctx.instance.runtime_properties[EXTRA_SPECS_PROPERTY] = extra_specs
+
+
+def _set_tenants_access(ctx, nova_client, flavor):
+    tenants = ctx.node.properties.get(TENANTS_PROPERTY, [])
+
+    for tenant in tenants:
+        ctx.logger.info(
+            'Adding tenant access: {0} for flavor: {1}'
+            .format(tenant, flavor.to_dict())
+        )
+        nova_client.flavor_access.add_tenant_access(flavor, tenant)
+
+    ctx.instance.runtime_properties[TENANTS_PROPERTY] = tenants
 
 
 @operation
@@ -36,15 +70,25 @@ def create(nova_client, args, **kwargs):
         return
 
     flavor_dict = create_object_dict(ctx, FLAVOR_OPENSTACK_TYPE, args, {})
+    ctx.logger.info('Creating flavor: {0}'.format(flavor_dict))
+
     flavor = nova_client.flavors.create(**flavor_dict)
     set_openstack_runtime_properties(ctx, flavor, FLAVOR_OPENSTACK_TYPE)
+
+    _set_extra_specs(ctx, flavor)
+    _set_tenants_access(ctx, nova_client, flavor)
 
 
 @operation
 @with_nova_client
 def delete(nova_client, **kwargs):
-    delete_resource_and_runtime_properties(ctx, nova_client,
-                                           RUNTIME_PROPERTIES_KEYS)
+    delete_resource_and_runtime_properties(
+        ctx,
+        nova_client,
+        RUNTIME_PROPERTIES_KEYS
+    )
+
+    delete_runtime_properties(ctx, [EXTRA_SPECS_PROPERTY, TENANTS_PROPERTY])
 
 
 @with_nova_client

--- a/nova_plugin/tests/test_flavor.py
+++ b/nova_plugin/tests/test_flavor.py
@@ -15,13 +15,16 @@ from openstack_plugin_common import (
     OPENSTACK_ID_PROPERTY,
     OPENSTACK_NAME_PROPERTY,
     OPENSTACK_TYPE_PROPERTY
-    )
-from nova_plugin.flavor import FLAVOR_OPENSTACK_TYPE
+)
+from nova_plugin.flavor import (
+    FLAVOR_OPENSTACK_TYPE,
+    EXTRA_SPECS_PROPERTY,
+    TENANTS_PROPERTY
+)
 import nova_plugin
 
 
 class TestFlavor(unittest.TestCase):
-
     test_id = 'test-id'
     test_name = 'test-name'
     updated_name = 'updated-name'
@@ -31,6 +34,8 @@ class TestFlavor(unittest.TestCase):
         def __init__(self, id, name):
             self._id = id
             self._name = name
+            self._set_keys_called = False
+            self._set_keys_last_call_params = {}
 
         @property
         def id(self):
@@ -40,6 +45,14 @@ class TestFlavor(unittest.TestCase):
         def name(self):
             return self._name
 
+        def set_keys(self, extra_specs):
+            self._set_keys_called = True
+            self._set_keys_last_call_params = extra_specs
+
+        def assert_set_keys_called_with(self, test, params):
+            test.assertTrue(self._set_keys_called)
+            test.assertEquals(self._set_keys_last_call_params, params)
+
         def to_dict(self):
             return {'name': self.name, 'id': self.id}
 
@@ -48,27 +61,42 @@ class TestFlavor(unittest.TestCase):
         nova_client.flavors.create.return_value = mock_flavor
         nova_client.flavors.list.return_value = [mock_flavor]
         nova_client.flavors.find.return_value = mock.MagicMock(
-            id=self.test_name)
+            id=self.test_name
+        )
+        nova_client.flavor_access.add_tenant_access = mock.MagicMock()
+
         return nova_client
 
-    def mock_ctx(self, test_vars, test_id,
-                 test_deployment_id, runtime_properties=None):
+    def mock_ctx(self,
+                 test_vars,
+                 test_id,
+                 test_deployment_id,
+                 runtime_properties=None):
         ctx = MockContext()
+
         ctx.node = MockNodeContext(properties=test_vars)
         ctx.bootstrap_context = BootstrapContext(
-            common_test.BOOTSTRAP_CONTEXTS_WITHOUT_PREFIX[0])
+            common_test.BOOTSTRAP_CONTEXTS_WITHOUT_PREFIX[0]
+        )
         ctx.instance = MockNodeInstanceContext(
-            id=test_id, runtime_properties=runtime_properties or {})
+            id=test_id,
+            runtime_properties=runtime_properties or {}
+        )
         ctx.deployment = mock.Mock()
         ctx.deployment.id = test_deployment_id
         ctx.type = NODE_INSTANCE
         ctx.logger = mock.Mock()
+
         current_ctx.set(ctx)
         return ctx
 
-    @mock.patch('openstack_plugin_common._handle_kw',
-                autospec=True, return_value=None)
-    def test_keystone_flavor_create_and_delete(self, *_):
+    @mock.patch(
+        'openstack_plugin_common._handle_kw',
+        autospec=True,
+        return_value=None
+    )
+    def test_flavor_create_and_delete(self, *_):
+        # given
         test_vars = {
             'flavor': {},
             'resource_id': ''
@@ -78,38 +106,143 @@ class TestFlavor(unittest.TestCase):
         nova_plugin.flavor.ctx = ctx
         mock_flavor = self.MockFlavorOS(self.test_id, self.test_name)
         nova_client = self.mock_nova_client(mock_flavor)
-        nova_plugin.flavor.create(nova_client, {})
-        self.assertEqual(self.test_name,
-                         ctx.instance.runtime_properties[
-                             OPENSTACK_NAME_PROPERTY])
-        self.assertEqual(self.test_id,
-                         ctx.instance.runtime_properties[
-                             OPENSTACK_ID_PROPERTY])
-        self.assertEqual(FLAVOR_OPENSTACK_TYPE,
-                         ctx.instance.runtime_properties[
-                             OPENSTACK_TYPE_PROPERTY])
 
+        # when (create)
+        nova_plugin.flavor.create(nova_client, {})
+
+        # then (create)
+        self.assertEqual(
+            self.test_name,
+            ctx.instance.runtime_properties[OPENSTACK_NAME_PROPERTY]
+        )
+        self.assertEqual(
+            self.test_id,
+            ctx.instance.runtime_properties[OPENSTACK_ID_PROPERTY]
+        )
+        self.assertEqual(
+            FLAVOR_OPENSTACK_TYPE,
+            ctx.instance.runtime_properties[OPENSTACK_TYPE_PROPERTY]
+        )
+
+        # when (delete)
         nova_plugin.flavor.delete(nova_client=nova_client)
-        self.assertNotIn(OPENSTACK_ID_PROPERTY,
-                         ctx.instance.runtime_properties)
-        self.assertNotIn(OPENSTACK_NAME_PROPERTY,
-                         ctx.instance.runtime_properties)
-        self.assertNotIn(OPENSTACK_TYPE_PROPERTY,
-                         ctx.instance.runtime_properties)
+
+        # then (delete)
+        self.assertNotIn(
+            OPENSTACK_ID_PROPERTY,
+            ctx.instance.runtime_properties
+        )
+        self.assertNotIn(
+            OPENSTACK_NAME_PROPERTY,
+            ctx.instance.runtime_properties
+        )
+        self.assertNotIn(
+            OPENSTACK_TYPE_PROPERTY,
+            ctx.instance.runtime_properties
+        )
+
+    @mock.patch(
+        'openstack_plugin_common._handle_kw',
+        autospec=True,
+        return_value=None
+    )
+    def test_flavor_create_and_delete_with_extra_specs_and_tenants(self, *_):
+        # given
+        test_vars_tenant_id = 'some_tenant_id'
+        test_vars_tenants = [test_vars_tenant_id]
+        test_vars_extra_specs = {
+            'key1': 'value1',
+            'key2': 'value2'
+        }
+        test_vars = {
+            'flavor': {},
+            'extra_specs': test_vars_extra_specs,
+            'tenants': test_vars_tenants,
+            'resource_id': ''
+        }
+
+        ctx = self.mock_ctx(test_vars, self.test_id, self.test_deployment_id)
+        nova_plugin.flavor.ctx = ctx
+        mock_flavor = self.MockFlavorOS(self.test_id, self.test_name)
+        nova_client = self.mock_nova_client(mock_flavor)
+
+        # when (create)
+        nova_plugin.flavor.create(nova_client, {})
+
+        # then (create)
+        mock_flavor.assert_set_keys_called_with(self, test_vars_extra_specs)
+        nova_client.flavor_access.add_tenant_access.assert_called_once_with(
+            mock_flavor,
+            test_vars_tenant_id
+        )
+
+        self.assertEqual(
+            self.test_name,
+            ctx.instance.runtime_properties[OPENSTACK_NAME_PROPERTY]
+        )
+        self.assertEqual(
+            self.test_id,
+            ctx.instance.runtime_properties[OPENSTACK_ID_PROPERTY]
+        )
+        self.assertEqual(
+            FLAVOR_OPENSTACK_TYPE,
+            ctx.instance.runtime_properties[OPENSTACK_TYPE_PROPERTY]
+        )
+        self.assertEqual(
+            test_vars_extra_specs,
+            ctx.instance.runtime_properties[EXTRA_SPECS_PROPERTY]
+        )
+        self.assertEqual(
+            test_vars_tenants,
+            ctx.instance.runtime_properties[TENANTS_PROPERTY]
+        )
+
+        # when (delete)
+        nova_plugin.flavor.delete(nova_client=nova_client)
+
+        # then (delete)
+        self.assertNotIn(
+            OPENSTACK_ID_PROPERTY,
+            ctx.instance.runtime_properties
+        )
+        self.assertNotIn(
+            OPENSTACK_NAME_PROPERTY,
+            ctx.instance.runtime_properties
+        )
+        self.assertNotIn(
+            OPENSTACK_TYPE_PROPERTY,
+            ctx.instance.runtime_properties
+        )
+        self.assertNotIn(
+            EXTRA_SPECS_PROPERTY,
+            ctx.instance.runtime_properties
+        )
+        self.assertNotIn(
+            TENANTS_PROPERTY,
+            ctx.instance.runtime_properties
+        )
 
     def test_list_flavors(self, *_):
+        # given
         test_vars = {
             'flavor': {},
             'resource_id': ''
         }
-        ctx = self.mock_ctx(test_vars,
-                            self.test_id,
-                            self.test_deployment_id,
-                            {OPENSTACK_ID_PROPERTY: self.test_id})
+
+        ctx = self.mock_ctx(
+            test_vars,
+            self.test_id,
+            self.test_deployment_id,
+            {OPENSTACK_ID_PROPERTY: self.test_id}
+        )
         mock_flavor = self.MockFlavorOS(self.test_id, self.test_name)
         nova_client = self.mock_nova_client(mock_flavor)
         nova_plugin.flavor.ctx = ctx
+
+        # when
         nova_plugin.flavor.list_flavors(args={}, nova_client=nova_client)
+
+        # then
         flavor_list = FLAVOR_OPENSTACK_TYPE + '_list'
         self.assertIn(flavor_list, ctx.instance.runtime_properties)
         self.assertEqual(1, len(ctx.instance.runtime_properties[flavor_list]))

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1138,6 +1138,15 @@ node_types:
         description: >
           key-value user configuration, according to:
           https://developer.openstack.org/api-ref/compute/#create-flavor
+      extra_specs:
+        default: {}
+        description: >
+          key-value user configuration, according to:
+          https://developer.openstack.org/api-ref/compute/#create-extra-specs-for-a-flavor
+      tenants:
+        default: []
+        description: >
+          List of tenants to add to flavor access
       use_external_resource:
         default: false
         description: >


### PR DESCRIPTION
Support for:
* https://developer.openstack.org/api-ref/compute/#create-extra-specs-for-a-flavor
* https://developer.openstack.org/api-ref/compute/#add-flavor-access-to-tenant-addtenantaccess-action

Required for one of customers projects.
