### PR TITLE
Get rid of cloudify._compat dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,13 @@ jobs:
           name: install futurize
           command: pip install future --user
       - run:
+          # those modules contain code that futurize would want to change,
+          # so let's just remove them so that it doesn't report on them
+          # (there's no "exclude" functionality in futurize)
+          name: remove compat modules
+          command: |
+            rm openstack_sdk/_compat.py
+      - run:
           name: find python3-incompatible code
           command: |
             FUTURIZE="futurize ."

--- a/openstack_plugin/resources/compute/host_aggregate.py
+++ b/openstack_plugin/resources/compute/host_aggregate.py
@@ -16,7 +16,6 @@
 # Third party imports
 from cloudify import ctx
 from cloudify.exceptions import NonRecoverableError
-from cloudify._compat import text_type
 
 # Local imports
 from openstack_sdk.resources.compute import OpenstackHostAggregate
@@ -28,6 +27,8 @@ from openstack_plugin.utils import (
     add_resource_list_to_runtime_properties,
     reset_dict_empty_keys
 )
+# Py2/3 compatibility
+from openstack_sdk._compat import text_type
 
 
 def _add_hosts(openstack_resource, hosts):

--- a/openstack_plugin/utils.py
+++ b/openstack_plugin/utils.py
@@ -32,7 +32,9 @@ from cloudify import ctx
 from cloudify.exceptions import (NonRecoverableError, OperationRetry)
 from cloudify.utils import exception_to_error_cause
 from cloudify.constants import NODE_INSTANCE, RELATIONSHIP_INSTANCE
-from cloudify._compat import text_type, PY2
+
+# Py2/3 compatibility
+from openstack_sdk._compat import text_type, PY2
 
 
 # Local imports

--- a/openstack_sdk/_compat.py
+++ b/openstack_sdk/_compat.py
@@ -1,0 +1,32 @@
+########
+# Copyright (c) 2020 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+"""Python 2 + 3 compatibility utils"""
+# flake8: noqa
+
+import sys
+PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    text_type = unicode
+
+else:
+    text_type = str
+
+
+__all__ = [
+    'PY2', 'text_type',
+]

--- a/openstack_sdk/common.py
+++ b/openstack_sdk/common.py
@@ -20,8 +20,8 @@ import uuid
 import openstack
 import openstack.exceptions
 
-# Cloudify import (Py2/3 compatibility)
-from cloudify._compat import text_type
+# Py2/3 compatibility
+from openstack_sdk._compat import text_type
 
 
 class QuotaException(Exception):


### PR DESCRIPTION
Python2/3 compatibility imports moved to `openstack_sdk._compat`